### PR TITLE
Fix Python dependency conflicts for Ubuntu 16.04 + conda environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bs4==0.0.2
 cachetools==5.3.1
 certifi==2023.5.7
 charset-normalizer==3.1.0
-chromadb==0.3.23
+#chromadb==0.3.23
 click==8.1.3
 clickhouse-connect==0.6.4
 cmake==3.26.4
@@ -26,8 +26,8 @@ dill==0.3.7
 distro==1.8.0
 duckdb==0.8.1
 exceptiongroup==1.1.1
-faiss-cpu==1.7.4
-fastapi==0.98.0
+#faiss-cpu==1.7.4
+fastapi>=0.100.0
 filelock==3.12.2
 Flask==2.3.2
 flatbuffers==23.5.26
@@ -51,12 +51,12 @@ graphlib-backport==1.0.3
 greenlet==2.0.2
 groq==0.5.0
 h11==0.14.0
-hnswlib==0.7.0
+#hnswlib==0.7.0
 httpcore>=1.0.0,<2
 httplib2==0.22.0
 httptools==0.5.0
 httpx>=0.27.0,<1
-huggingface-hub==0.15.1
+huggingface-hub>=0.15.1
 humanfriendly==10.0
 idna==3.4
 importlib-metadata==6.7.0
@@ -65,12 +65,12 @@ Jinja2==3.1.2
 joblib==1.2.0
 jsonpatch==1.33
 jsonpointer==2.4
-langchain==0.0.230
-langchain-anthropic>=0.1.0
-langchain-core==0.1.44
-langchain-google-genai>=0.1.0
+langchain==0.1.20
+langchain-anthropic==0.1.13
+langchain-core==0.1.52
+langchain-google-genai==0.0.11
 langchain-groq==0.1.2
-langchainplus-sdk==0.0.20
+#langchainplus-sdk==0.0.20
 langsmith==0.1.49
 lit==16.0.6
 lz4==4.3.2
@@ -87,9 +87,9 @@ mypy-extensions==1.0.0
 networkx==3.1
 nltk==3.8.1
 numexpr==2.8.4
-numpy==1.25.2
+#numpy==1.25.2
 onnxruntime==1.16.3
-openai==0.27.8
+openai>=1.0.0
 openapi-schema-pydantic==1.2.4
 opencv-python
 orjson==3.10.1
@@ -105,7 +105,7 @@ pyarrow==14.0.1
 pyarrow-hotfix==0.6
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
-pydantic==1.10.9
+pydantic>=2.0.0
 PyJWT==2.7.0
 pyparsing==3.1.0
 pypdf==3.17.1
@@ -130,7 +130,7 @@ six==1.16.0
 sniffio==1.3.0
 soupsieve==2.5
 SQLAlchemy==2.0.16
-starlette==0.27.0
+starlette>=0.27.0
 sympy==1.12
 tenacity==8.2.2
 threadpoolctl==3.1.0
@@ -176,7 +176,7 @@ paramiko>=3.0
 pystray>=0.19.0
 
 # LuxTTS — 48kHz voice cloning TTS (150x realtime GPU, Apache 2.0)
-luxtts>=0.1.0
+#luxtts>=0.1.0  # not on PyPI
 soundfile>=0.12.0
 
 # Aider Core — vendored modules for code intelligence (repo map, search/replace, linting)


### PR DESCRIPTION
- Comment out luxtts, langchain-classic (not on PyPI)
- Comment out hnswlib, chromadb, faiss-cpu, numpy (require GCC>=9, installed via conda)
- Upgrade langchain stack to compatible versions: langchain==0.1.20, langchain-core==0.1.52 langchain-anthropic==0.1.13, langchain-groq==0.1.2 langchain-google-genai==0.0.11, langsmith==0.1.49
- Upgrade openai>=1.0.0, pydantic>=2.0.0, fastapi>=0.100.0
- Loosen version pins to allow pip resolver to succeed