### PR TITLE
fix(release): unblock ISO pipeline + register Nunba as native app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,26 +231,46 @@ jobs:
 
       - name: Build ${{ matrix.target }}
         working-directory: nixos
+        shell: bash
         run: |
-          time nix build .#${{ matrix.target }} --no-link --print-out-paths --show-trace \
-            | tee /tmp/build-output.txt
+          set -eo pipefail
+          # pipefail + set -e: `tee` no longer hides a failed `nix build`.
+          # Retry once: the magic-nix-cache GitHub API is rate-limited
+          # and transient 429s shouldn't break a 90-minute OS build.
+          for attempt in 1 2; do
+            echo "=== nix build attempt $attempt ==="
+            if time nix build .#${{ matrix.target }} \
+                --no-link --print-out-paths --show-trace \
+                --option narinfo-cache-negative-ttl 0 \
+                | tee /tmp/build-output.txt; then
+              break
+            fi
+            if [[ $attempt == 2 ]]; then
+              echo "ERROR: nix build failed after retry"
+              exit 1
+            fi
+            echo "Retrying after 30s (cache transients)..."
+            sleep 30
+          done
 
       - name: Checksum + Torrent
+        shell: bash
         run: |
+          set -eo pipefail
           echo "=== Build output ==="
-          cat /tmp/build-output.txt || echo "No build output file"
+          cat /tmp/build-output.txt || { echo "No build output file"; exit 1; }
           BUILD_PATH=$(cat /tmp/build-output.txt | head -1 | tr -d '[:space:]')
           echo "BUILD_PATH: '$BUILD_PATH'"
 
           if [[ -z "$BUILD_PATH" ]]; then
             echo "ERROR: Nix build produced no output path"
             echo "Check the Build step logs above for errors"
-            exit 0
+            exit 1
           fi
 
           echo "=== Listing build path ==="
-          ls -la "$BUILD_PATH" 2>/dev/null || echo "Path does not exist: $BUILD_PATH"
-          find "$BUILD_PATH" -maxdepth 3 -type f 2>/dev/null | head -20 || true
+          ls -la "$BUILD_PATH" || { echo "Path does not exist: $BUILD_PATH"; exit 1; }
+          find "$BUILD_PATH" -maxdepth 3 -type f | head -20 || true
 
           # Find ISO file
           FILE=""
@@ -264,8 +284,8 @@ jobs:
           echo "FILE: '$FILE'"
 
           if [[ -z "${FILE:-}" ]] || [[ ! -f "$FILE" ]]; then
-            echo "No output file found in build path"
-            exit 0
+            echo "ERROR: No .iso/.qcow2/.raw/.img found in $BUILD_PATH"
+            exit 1
           fi
 
           BASENAME=$(basename "$FILE")
@@ -303,12 +323,36 @@ jobs:
           path: /tmp/release-artifacts/
           retention-days: 30
 
-      - name: Attach to GitHub Release
+      - name: Attach to GitHub Release (manual dispatch)
         if: github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: "v${{ github.event.inputs.version }}"
           files: /tmp/release-artifacts/*
+
+      # On push to main: attach ISO + torrent + sha256 to the existing
+      # "latest" release so docs.hevolve.ai/downloads links resolve to
+      # fresh artifacts. Non-breaking for signed releases — the signed
+      # release_manifest.json is untouched; ISOs verify via their own
+      # .sha256 file which is regenerated each push.
+      - name: Attach to latest release (push to main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_TAG=$(gh release list --repo "${{ github.repository }}" \
+            --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+          if [[ -z "$LATEST_TAG" ]]; then
+            echo "No release found — skipping asset upload"
+            exit 0
+          fi
+          echo "Uploading ${{ matrix.target }} artifacts to $LATEST_TAG"
+          cd /tmp/release-artifacts
+          for f in *; do
+            [[ -f "$f" ]] || continue
+            gh release upload "$LATEST_TAG" "$f" \
+              --repo "${{ github.repository }}" --clobber
+          done
 
   # ═══════════════════════════════════════════════════════════
   # 4. Deploy Docs to GitHub Pages

--- a/core/platform/bootstrap.py
+++ b/core/platform/bootstrap.py
@@ -321,6 +321,17 @@ def _register_native_apps(apps: AppRegistry) -> None:
     """
     NATIVE_APPS = [
         AppManifest(
+            id='nunba', name='Nunba', version='auto',
+            type=AppType.DESKTOP_APP.value, icon='hub',
+            entry={'exec': 'nunba',
+                   'http': 'http://localhost:5000',
+                   'backend': 'http://localhost:6777'},
+            group='System', platforms=['linux', 'windows', 'macos'],
+            permissions=['network', 'display'],
+            description='HART OS companion app — chat, communities, agents',
+            tags=['chat', 'agents', 'ui', 'nunba', 'hart'],
+        ),
+        AppManifest(
             id='rustdesk', name='RustDesk', version='auto',
             type=AppType.DESKTOP_APP.value, icon='desktop_windows',
             entry={'exec': 'rustdesk', 'bridge': 'rustdesk_bridge'},

--- a/tests/unit/test_model_lifecycle.py
+++ b/tests/unit/test_model_lifecycle.py
@@ -129,6 +129,12 @@ class TestPriorityUpdates:
     def manager(self):
         from integrations.service_tools.model_lifecycle import ModelLifecycleManager
         mgr = ModelLifecycleManager()
+        # Isolate from persisted hints left by prior tests — the lifecycle
+        # state file at ~/.hevolve/lifecycle_state.json is process-global.
+        # A prior test that calls _on_tool_stopped persists hints, which
+        # would make _on_tool_started flip hive_boost=True and skew the
+        # idle/evictable threshold tests below.
+        mgr._persisted_hints.clear()
         return mgr
 
     def test_active_inference_sets_active(self, manager):


### PR DESCRIPTION
## Summary
- **ISO pipeline** silently green-flagged broken builds — `nix build` failed from magic-nix-cache rate limits but the script did `exit 0`. v1.0.0 release has zero assets, so every `docs.hevolve.ai/downloads` link 404s.
- **test gate** was blocked by a flaky `test_old_access_sets_idle` whose fixture loaded persisted hints from `~/.hevolve/lifecycle_state.json` written by prior tests.
- **Nunba** was packaged as a nix systemd service + .desktop entry but not registered in the runtime `AppRegistry`, so LiquidUI and the agentic runtime couldn't see it.

## Fixes
- `.github/workflows/release.yml`: `set -eo pipefail`, hard-fail on empty `BUILD_PATH` / missing ISO, retry `nix build` once for transient cache 429s, and attach ISO+torrent+sha256 to latest release on push to main.
- `tests/unit/test_model_lifecycle.py`: `TestPriorityUpdates.manager` fixture clears `_persisted_hints` for hermetic runs.
- `core/platform/bootstrap.py`: Nunba added to `NATIVE_APPS` so `shutil.which('nunba')` promotes it to a first-class registered desktop app.

## Test plan
- [x] Local AST parse of edited files
- [ ] Release workflow triggers on merge → `build-iso` matrix produces ISOs
- [ ] ISOs upload to v1.0.0 release via `gh release upload --clobber`
- [ ] docs.hevolve.ai/downloads links resolve to real artifacts
- [ ] `test` job passes (`test_old_access_sets_idle` green)