### PR TITLE
feat(livekit): self-hosted SFU supervisor + mesh-first promotion (#275)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,31 @@ RUN python scripts/compile_hevolveai.py --strip-source \
     find /usr/local/lib -path '*hevolveai*dist-info/RECORD' -delete 2>/dev/null || true && \
     find /usr/local/lib -path '*embodied*ai*dist-info/RECORD' -delete 2>/dev/null || true
 
-EXPOSE 6777
+# ── Layer 4: LiveKit SFU binary (regional/flat — voice/video for >4-party calls) ──
+# Pre-stage the official livekit-server Go binary at /usr/local/bin so
+# the supervisor in integrations.social.livekit_supervisor doesn't need
+# to download it at first start.  Skipped automatically at runtime when
+# HEVOLVE_DEPLOY_MODE=central or LIVEKIT_DISABLE=1 (cloud / sync-only
+# deployments use Dockerfile.prod which omits this entire layer).
+#
+# The supervisor checks ~/.hevolve/livekit/livekit-server first AND
+# falls through to PATH lookup, so dropping it at /usr/local/bin works.
+ARG LIVEKIT_VERSION=1.7.2
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) tag=linux_amd64 ;; \
+      arm64) tag=linux_arm64 ;; \
+      *) echo "Unsupported arch $arch for livekit-server" >&2; exit 1 ;; \
+    esac; \
+    url="https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/livekit_${LIVEKIT_VERSION}_${tag}.tar.gz"; \
+    curl -fsSL "$url" -o /tmp/lk.tgz && \
+    tar -xzf /tmp/lk.tgz -C /tmp && \
+    install -m 0755 /tmp/livekit-server /usr/local/bin/livekit-server && \
+    rm -f /tmp/lk.tgz /tmp/livekit-server
+
+# LiveKit RTC ports: WS signaling 7880, TCP fallback 7881, UDP range
+# 50000-60000 for media.  Operators expose only what their NAT requires.
+EXPOSE 6777 7880 7881
 
 CMD [ "python", "hart_intelligence_entry.py" ]

--- a/core/compute_optimizer.py
+++ b/core/compute_optimizer.py
@@ -282,93 +282,106 @@ class ComputeOptimizer:
 
     # ── Snapshot ──────────────────────────────────────────────────
 
-    def snapshot(self) -> SystemSnapshot:
-        """Capture current system state. Returns a SystemSnapshot.
+    # ── Snapshot collectors (extracted helpers — single source of truth
+    #     for cpu/ram/swap/disk/network reads + per-process walk + GPU
+    #     detection.  Both ``snapshot()`` (the canonical full-snapshot
+    #     entry, behavior preserved exactly) and ``get_latest_snapshot``
+    #     (the cached cross-module accessor) compose these helpers.
+    #     Splitting the collectors lets cross-module readers (e.g.
+    #     ResourceGovernor, which only needs aggregates) request just
+    #     the cheap path without paying the per-process walk's GIL cost.
+    # ──────────────────────────────────────────────────────────────────
 
-        Uses psutil if available; falls back to minimal OS-level data.
-        GPU info via vram_manager (single source of truth).
+    def _collect_aggregates(self, snap: SystemSnapshot) -> None:
+        """Populate cpu/ram/swap/disk/network on snap (cheap, GIL-light).
+
+        Always safe to call — has zero per-process / per-PID cost.  Lifted
+        verbatim from the original ``snapshot`` body, behavior preserved.
         """
-        snap = SystemSnapshot(
-            timestamp=time.time(),
-            platform_name=self._platform,
-        )
-
         psutil = _try_import_psutil()
-        if psutil is not None:
-            # CPU — non-blocking (interval=None returns since-last-call)
-            snap.cpu_percent = psutil.cpu_percent(interval=None)
+        if psutil is None:
+            return
+        # CPU — non-blocking (interval=None returns since-last-call)
+        snap.cpu_percent = psutil.cpu_percent(interval=None)
 
-            # RAM
-            mem = psutil.virtual_memory()
-            snap.ram_percent = mem.percent
-            snap.ram_used_gb = mem.used / (1024 ** 3)
-            snap.ram_total_gb = mem.total / (1024 ** 3)
+        # RAM
+        mem = psutil.virtual_memory()
+        snap.ram_percent = mem.percent
+        snap.ram_used_gb = mem.used / (1024 ** 3)
+        snap.ram_total_gb = mem.total / (1024 ** 3)
 
-            # Swap
-            swap = psutil.swap_memory()
-            snap.swap_percent = swap.percent if swap.total > 0 else 0.0
+        # Swap
+        swap = psutil.swap_memory()
+        snap.swap_percent = swap.percent if swap.total > 0 else 0.0
 
-            # Disk usage (root partition)
-            try:
-                root = 'C:\\' if self._platform == 'Windows' else '/'
-                disk = psutil.disk_usage(root)
-                snap.disk_usage_percent = disk.percent
-            except Exception:
-                pass
+        # Disk usage (root partition)
+        try:
+            root = 'C:\\' if self._platform == 'Windows' else '/'
+            disk = psutil.disk_usage(root)
+            snap.disk_usage_percent = disk.percent
+        except Exception:
+            pass
 
-            # Disk I/O
-            try:
-                dio = psutil.disk_io_counters()
-                if dio:
-                    snap.disk_io_read_mb = dio.read_bytes / (1024 ** 2)
-                    snap.disk_io_write_mb = dio.write_bytes / (1024 ** 2)
-            except Exception:
-                pass
+        # Disk I/O
+        try:
+            dio = psutil.disk_io_counters()
+            if dio:
+                snap.disk_io_read_mb = dio.read_bytes / (1024 ** 2)
+                snap.disk_io_write_mb = dio.write_bytes / (1024 ** 2)
+        except Exception:
+            pass
 
-            # Network I/O
-            try:
-                nio = psutil.net_io_counters()
-                if nio:
-                    snap.net_sent_mb = nio.bytes_sent / (1024 ** 2)
-                    snap.net_recv_mb = nio.bytes_recv / (1024 ** 2)
-            except Exception:
-                pass
+        # Network I/O
+        try:
+            nio = psutil.net_io_counters()
+            if nio:
+                snap.net_sent_mb = nio.bytes_sent / (1024 ** 2)
+                snap.net_recv_mb = nio.bytes_recv / (1024 ** 2)
+        except Exception:
+            pass
 
-            # Top processes — GATED on ANY resource breach.
-            #
-            # WHY GATED: psutil.process_iter(['memory_percent']) on Windows
-            # walks every PID and issues OpenProcess + GetProcessMemoryInfo
-            # per process, all under the GIL.  On a typical Windows box
-            # (~150-300 PIDs) that's 200ms-2s of GIL-held CPU per call —
-            # which, fired every MONITOR_INTERVAL seconds, periodically
-            # stalls WAMP heartbeats, the chat hot path, and daemon yield
-            # gates.  py-spy thread dumps caught exactly this loop active+gil.
-            # The data is only read by `_suggest_optimizations` when a
-            # threshold is breached; emitting an empty list when nothing
-            # is hot costs nothing downstream.  Gate covers cpu/ram/swap/
-            # disk so any breach (incl. 89.5% RAM situations) still gets
-            # the per-process detail it needs.
-            if (snap.cpu_percent > CPU_HIGH_THRESHOLD
-                    or snap.ram_percent > RAM_HIGH_THRESHOLD
-                    or snap.swap_percent > SWAP_HIGH_THRESHOLD
-                    or snap.disk_usage_percent > DISK_HIGH_THRESHOLD):
-                try:
-                    procs = []
-                    for proc in psutil.process_iter(['pid', 'name', 'cpu_percent', 'memory_percent']):
-                        info = proc.info
-                        if info.get('cpu_percent', 0) > 0.1:
-                            procs.append({
-                                'pid': info['pid'],
-                                'name': info.get('name', ''),
-                                'cpu_percent': round(info.get('cpu_percent', 0), 1),
-                                'mem_percent': round(info.get('memory_percent', 0), 1),
-                            })
-                    procs.sort(key=lambda p: p['cpu_percent'], reverse=True)
-                    snap.top_processes = procs[:10]
-                except Exception:
-                    pass
+    def _collect_top_processes(self, snap: SystemSnapshot) -> None:
+        """Populate snap.top_processes via psutil.process_iter (expensive).
 
-        # GPU (via vram_manager)
+        WHY GATED: ``psutil.process_iter(['memory_percent'])`` on Windows
+        walks every PID and issues OpenProcess + GetProcessMemoryInfo
+        per process, all under the GIL.  On a typical Windows box
+        (~150-300 PIDs) that's 200ms-2s of GIL-held CPU per call — which,
+        fired every MONITOR_INTERVAL seconds, periodically stalls WAMP
+        heartbeats, the chat hot path, and daemon yield gates.  py-spy
+        thread dumps caught exactly this loop active+gil.  The data is
+        only read by ``_suggest_optimizations`` when a threshold is
+        breached; emitting an empty list when nothing is hot costs
+        nothing downstream.  Gate covers cpu/ram/swap/disk so any
+        breach (incl. 89.5% RAM situations) still gets the per-process
+        detail it needs.
+        """
+        psutil = _try_import_psutil()
+        if psutil is None:
+            return
+        if not (snap.cpu_percent > CPU_HIGH_THRESHOLD
+                or snap.ram_percent > RAM_HIGH_THRESHOLD
+                or snap.swap_percent > SWAP_HIGH_THRESHOLD
+                or snap.disk_usage_percent > DISK_HIGH_THRESHOLD):
+            return
+        try:
+            procs = []
+            for proc in psutil.process_iter(['pid', 'name', 'cpu_percent', 'memory_percent']):
+                info = proc.info
+                if info.get('cpu_percent', 0) > 0.1:
+                    procs.append({
+                        'pid': info['pid'],
+                        'name': info.get('name', ''),
+                        'cpu_percent': round(info.get('cpu_percent', 0), 1),
+                        'mem_percent': round(info.get('memory_percent', 0), 1),
+                    })
+            procs.sort(key=lambda p: p['cpu_percent'], reverse=True)
+            snap.top_processes = procs[:10]
+        except Exception:
+            pass
+
+    def _collect_gpu(self, snap: SystemSnapshot) -> None:
+        """Populate snap GPU fields via vram_manager (single source of truth)."""
         gpu_info = _try_detect_gpu()
         if gpu_info.get('cuda_available'):
             snap.gpu_mem_total_gb = gpu_info.get('total_gb', 0)
@@ -376,11 +389,90 @@ class ComputeOptimizer:
             if snap.gpu_mem_total_gb > 0:
                 snap.gpu_util_percent = (snap.gpu_mem_used_gb / snap.gpu_mem_total_gb) * 100
 
+    def _store_snapshot(self, snap: SystemSnapshot) -> None:
+        """Append to history deque + update _last_snapshot under lock."""
         with self._lock:
             self._snapshots.append(snap)
             self._last_snapshot = snap
 
+    def snapshot(self) -> SystemSnapshot:
+        """Capture current system state. Returns a SystemSnapshot.
+
+        Uses psutil if available; falls back to minimal OS-level data.
+        GPU info via vram_manager (single source of truth).
+
+        Behavior preserved from pre-refactor (2026-05-01 monitor
+        unification): aggregates + per-process top-N (when threshold
+        breached) + GPU + history append + _last_snapshot update +
+        return snap.  Body factored into ``_collect_*`` helpers so the
+        cross-module ``get_latest_snapshot`` accessor can reuse the
+        cheap aggregate path without paying the per-process GIL cost.
+        Existing callers (``_monitor_loop``, ``_emit_stats``, the
+        ``/optimizer/snapshot`` route, the test suite mocks) see the
+        identical SystemSnapshot they always have.
+        """
+        snap = SystemSnapshot(
+            timestamp=time.time(),
+            platform_name=self._platform,
+        )
+        self._collect_aggregates(snap)
+        self._collect_top_processes(snap)
+        self._collect_gpu(snap)
+        self._store_snapshot(snap)
         return snap
+
+    def get_latest_snapshot(self,
+                            max_age_s: float = 10.0,
+                            include_per_process: bool = False
+                            ) -> Optional[SystemSnapshot]:
+        """Cached system snapshot for cross-module readers.
+
+        Primary consumer: ``ResourceGovernor._monitor_loop`` (5s cadence)
+        which historically polled psutil itself, duplicating this
+        module's polls.  Returning a cached snapshot eliminates the
+        parallel psutil call site (root cause logged 2026-05-01:
+        py-spy caught both ``compute_optimizer_monitor`` AND
+        ``ResourceGovernor-Monitor`` active+gil simultaneously, both
+        in psutil cpu/memory paths).
+
+        Args:
+          max_age_s: return cached snap if it's younger than this.
+            Pass 0 to always force a fresh read.  Default 10s — well
+            under ResourceGovernor's IDLE_THRESHOLD_SECONDS (120s)
+            buffer for ACTIVE→IDLE transitions, so worst-case stale
+            data can't cause a perceptible mode-transition lag.
+          include_per_process: if True, run the expensive
+            ``process_iter`` walk during a refresh.  Default False —
+            cross-module readers like ResourceGovernor only need
+            aggregates and would otherwise force a per-process walk
+            on every 5s tick under sustained pressure.
+
+        Returns:
+          The most-recent SystemSnapshot.  Never None in steady state
+          (a fresh snapshot is built when cache is empty).  Returns
+          None only if snapshot construction itself raises (defensive
+          — caller should fall back to its own data source).
+        """
+        # Lock-free read of the atomic ref — fast path when cache hot.
+        last = self._last_snapshot
+        if last is not None and (time.time() - last.timestamp) < max_age_s:
+            return last
+        # Stale or missing — build a fresh snap.  Aggregates are
+        # always cheap; top-processes only if caller asked.
+        try:
+            snap = SystemSnapshot(
+                timestamp=time.time(),
+                platform_name=self._platform,
+            )
+            self._collect_aggregates(snap)
+            if include_per_process:
+                self._collect_top_processes(snap)
+            self._collect_gpu(snap)
+            self._store_snapshot(snap)
+            return snap
+        except Exception as e:
+            logger.debug("get_latest_snapshot refresh failed: %s", e)
+            return None
 
     # ── Threshold Detection ───────────────────────────────────────
 

--- a/core/error_advice.py
+++ b/core/error_advice.py
@@ -166,8 +166,17 @@ def _try_agent_remediation(
                 created_by='error_advice',
             )
     except Exception as e:
-        # Never let the remediation path crash the failure path
-        logger.debug(f"Agent remediation goal creation failed: {e}")
+        # Never let the remediation path crash the failure path —
+        # but DO surface the failure at WARNING so an open self-heal
+        # loop is visible in production logs.  Previously this was
+        # logger.debug, which hid silent breakage of the agentic
+        # remediation chain (e.g. db_session import fails in dev mode,
+        # GoalManager.create_goal raises on schema drift).  The chain
+        # being broken is exactly the operational signal we need.
+        logger.warning(
+            f"[error_advice/{category}] agent remediation goal creation "
+            f"failed: {type(e).__name__}: {e}"
+        )
 
 
 def handle_exception(

--- a/core/resource_governor.py
+++ b/core/resource_governor.py
@@ -854,11 +854,48 @@ class ResourceGovernor:
 
     # ── CPU / Memory / Battery / GPU ──────────────────────────────
 
+    def _get_optimizer_snapshot(self):
+        """Read the latest cached SystemSnapshot from ComputeOptimizer.
+
+        Returns the snap or None when the optimizer module/singleton
+        isn't available (e.g. degraded boot, or a deployment that
+        explicitly disables it).  ``include_per_process=False`` is
+        critical here — Governor only needs cpu/ram aggregates, and
+        forcing the optimizer's process_iter walk on every Governor
+        tick under sustained pressure would actually INCREASE GIL
+        contention (the opposite of why this consolidation exists).
+
+        Single source of truth for system pressure data — eliminates
+        the 2026-05-01 parallel-psutil-poll between Governor and
+        Optimizer that py-spy caught with BOTH monitors active+gil
+        simultaneously.
+        """
+        try:
+            from core.compute_optimizer import get_optimizer
+            return get_optimizer().get_latest_snapshot(
+                max_age_s=10.0, include_per_process=False,
+            )
+        except Exception:
+            return None
+
     def _get_cpu_usage(self) -> float:
         """Get current CPU usage as a float 0.0 to 1.0.
 
-        Tries psutil, then platform fallbacks.
+        Read order:
+          1. ComputeOptimizer's cached snapshot (canonical psutil reader).
+          2. Direct psutil fallback when optimizer unavailable.
+          3. Linux ``os.getloadavg()`` when psutil itself is missing.
+          4. Constant 0.3 as a last-resort moderate-usage assumption.
+
+        The first path is the steady-state hot path post-2026-05-01
+        unification — Governor used to call psutil.cpu_percent itself
+        every 5s, duplicating ComputeOptimizer's 15s poll.  The cached
+        snap gives us the same data with one writer.
         """
+        snap = self._get_optimizer_snapshot()
+        if snap is not None:
+            return snap.cpu_percent / 100.0
+
         psutil = _try_import_psutil()
         if psutil is not None:
             try:
@@ -881,8 +918,16 @@ class ResourceGovernor:
     def _get_memory_pressure(self) -> float:
         """Get memory pressure as a float 0.0 to 1.0.
 
-        Tries psutil, then /proc/meminfo on Linux.
+        Read order (mirrors ``_get_cpu_usage`` for symmetry):
+          1. ComputeOptimizer's cached snapshot (canonical psutil reader).
+          2. Direct psutil fallback when optimizer unavailable.
+          3. Linux ``/proc/meminfo`` when psutil itself is missing.
+          4. Constant 0.4 as a last-resort moderate-usage assumption.
         """
+        snap = self._get_optimizer_snapshot()
+        if snap is not None:
+            return snap.ram_percent / 100.0
+
         psutil = _try_import_psutil()
         if psutil is not None:
             try:

--- a/deploy/cloud/Dockerfile.prod
+++ b/deploy/cloud/Dockerfile.prod
@@ -140,6 +140,16 @@ RUN chown -R appuser:appgroup /app
 # Switch to non-root user
 USER appuser
 
+# ── LiveKit SFU intentionally NOT staged in this image ──
+# This is the *central* HARTOS image — sync / federation / backup-restore
+# only.  Voice/video calls run on regional or flat HARTOS nodes that DO
+# host an SFU (their image is built from the top-level Dockerfile, which
+# pre-stages livekit-server in Layer 4).  HEVOLVE_DEPLOY_MODE=central
+# below makes integrations.social.livekit_supervisor.supervisor_should_run()
+# return False, so no one tries to spawn a missing binary at startup.
+# Operators that override this for a hybrid deployment must mount the
+# binary at /usr/local/bin/livekit-server or set LIVEKIT_BINARY_PATH.
+
 # Environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -149,7 +159,9 @@ ENV PYTHONUNBUFFERED=1 \
     WORKERS=4 \
     THREADS=2 \
     TIMEOUT=120 \
-    HEVOLVE_ENFORCEMENT_MODE=hard
+    HEVOLVE_ENFORCEMENT_MODE=hard \
+    HEVOLVE_DEPLOY_MODE=central \
+    LIVEKIT_DISABLE=1
 
 # Expose port
 EXPOSE 8000

--- a/deploy/distro/first-boot/hart-first-boot.sh
+++ b/deploy/distro/first-boot/hart-first-boot.sh
@@ -219,6 +219,31 @@ for i in $(seq 1 20); do
     sleep 2
 done
 
+# ─── Step 5b: LiveKit SFU binary pre-stage (regional / flat) ───
+# HART OS distros are SFU hosts for their tenants (regional) or
+# single-user device (flat).  The LiveKit supervisor lazy-downloads
+# the binary on first call, but doing it during first-boot means
+# the first call is instant.  Skip on edge variants and OBSERVER tier
+# (constrained hardware — fall back to PeerLink-only signaling).
+if [[ "$VARIANT" != "edge" && "$TIER" != "OBSERVER" ]]; then
+    echo "[5b/5] Pre-staging LiveKit SFU binary..."
+    "$INSTALL_DIR/venv/bin/python" -c "
+import logging, sys
+logging.basicConfig(level=logging.INFO, format='  %(message)s')
+try:
+    from integrations.social.livekit_supervisor import ensure_binary
+    path = ensure_binary()
+    if path:
+        print(f'  LiveKit binary ready: {path}')
+    else:
+        print('  LiveKit binary unavailable — calls will use PeerLink mesh only')
+except Exception as e:
+    print(f'  LiveKit pre-stage skipped: {e}')
+    # Non-fatal — supervisor will retry on first call.
+    sys.exit(0)
+" 2>&1 || echo "  (non-fatal; supervisor will retry on demand)"
+fi
+
 # ─── Boot Audit ───
 if [[ -x "$INSTALL_DIR/deploy/distro/first-boot/hart-boot-audit.sh" ]]; then
     bash "$INSTALL_DIR/deploy/distro/first-boot/hart-boot-audit.sh" "$NODE_ID" "$TIER"

--- a/hart_intelligence_entry.py
+++ b/hart_intelligence_entry.py
@@ -3007,6 +3007,195 @@ def _handle_invite_friend_tool(input_text: str) -> str:
         return f"Invite_Friend error: {str(e)[:200]}"
 
 
+def _handle_join_external_room_tool(input_text: str) -> str:
+    """Join an external room (Discord channel, Slack channel, Telegram
+    super-group, Matrix room, Teams meet, WhatsApp group, etc.) on
+    behalf of the user, with consent + announcement guardrails.
+
+    Mirrors the _handle_connect_channel_tool pattern (G2, plan
+    elegant-spinning-avalanche).  Reuses canonical primitives:
+       - room_presence_service.gate (consent check, fail-closed)
+       - room_presence_service.announce_presence (HIVE MISSION
+         announcement on join)
+       - room_presence_service.listen_for_objection (auto-leave
+         on participant 'no AI' reply)
+       - ChannelRegistry.get / RoomCapableAdapter.join_room (transport)
+
+    Input formats:
+       - "<platform> <room_id_or_url>"            (default role=co_pilot)
+       - "<platform> <room_id> <role>"
+       - JSON: {"platform":..., "room":..., "role":...}
+
+    Roles ∈ {co_pilot, participant, note_taker, silent_observer, writer}.
+
+    Returns a human-readable string the LangChain agent can summarize.
+    Best-effort: never raises out, always returns a string.
+    """
+    import json as _json
+    try:
+        uid = thread_local_data.get_user_id()
+        if not uid:
+            return "Cannot join external room — no signed-in user in this session."
+
+        platform = ''
+        room_id = ''
+        role = 'co_pilot'
+        text = (input_text or '').strip()
+        if text.startswith('{'):
+            try:
+                parsed = _json.loads(text)
+                platform = (parsed.get('platform') or parsed.get('channel') or '').lower()
+                room_id = str(parsed.get('room') or parsed.get('room_id') or '')
+                role = (parsed.get('role') or 'co_pilot').lower()
+            except _json.JSONDecodeError:
+                pass
+        if not platform or not room_id:
+            parts = text.split(None, 2)
+            if len(parts) >= 1:
+                platform = platform or parts[0].lower()
+            if len(parts) >= 2:
+                room_id = room_id or parts[1]
+            if len(parts) >= 3 and not role:
+                role = parts[2].lower()
+
+        if not platform:
+            return (
+                "Which platform should I join? Tell me the platform "
+                "(discord, slack, telegram, matrix, teams, whatsapp) "
+                "and the room id or URL."
+            )
+        if not room_id:
+            return f"Which {platform} room should I join? Send the room id or URL."
+
+        # 1. Consent gate (canonical path)
+        from integrations.social.room_presence_service import (
+            announce_presence, gate, listen_for_objection,
+        )
+        allowed, reason = gate(str(uid), platform, room_id, role)
+        if not allowed:
+            # Surface a Liquid UI consent card so the user can grant in one click.
+            try:
+                from core.platform.service_registry import ServiceRegistry
+                _lui = ServiceRegistry.get('LiquidUIService')
+                if _lui:
+                    _lui.agent_ui_update(
+                        str(uid),
+                        {
+                            'type': 'approval',
+                            'title': 'Permission needed',
+                            'message': reason,
+                            'severity': 'info',
+                            'actions': [
+                                {'label': 'Open Privacy Settings',
+                                 'action': 'navigate',
+                                 'target': '/social/settings/privacy'},
+                            ],
+                        },
+                    )
+            except Exception as e:
+                logger.debug("Join_External_Room: consent UI emit skipped: %s", e)
+            return reason
+
+        # 2. Resolve adapter + check room-capable
+        try:
+            from integrations.channels.registry import get_registry
+            from integrations.channels.room_capable import (
+                UnsupportedRoomError, is_room_capable,
+            )
+            registry = get_registry()
+            adapter = registry.get(platform)
+        except Exception as e:
+            return f"Could not look up {platform} adapter: {str(e)[:160]}"
+        if adapter is None:
+            return (
+                f"No {platform} channel is configured. Set it up first "
+                f"via Connect_Channel ('add channel {platform}') and try again."
+            )
+        if not is_room_capable(adapter):
+            return (
+                f"The {platform} adapter is configured but does not yet "
+                f"support room/channel join semantics. Platform support "
+                f"is pending — for now you can use Connect_Channel for "
+                f"1:1 messaging."
+            )
+
+        # 3. Join via the adapter (RoomCapableAdapter.join_room)
+        import asyncio
+        try:
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    fut = asyncio.run_coroutine_threadsafe(
+                        adapter.join_room(room_id, role), loop)
+                    joined = fut.result(timeout=30)
+                else:
+                    joined = loop.run_until_complete(
+                        adapter.join_room(room_id, role))
+            except RuntimeError:
+                joined = asyncio.run(adapter.join_room(room_id, role))
+        except UnsupportedRoomError as e:
+            return f"{platform} doesn't support rooms here: {e}"
+        except Exception as e:
+            return f"Failed to join {platform}/{room_id}: {str(e)[:160]}"
+
+        if not joined:
+            return (
+                f"Could not join {platform}/{room_id} — the adapter "
+                f"refused the join (rate limit, missing permission, or "
+                f"network). Try again in a moment."
+            )
+
+        # 4. Announce presence (HIVE MISSION — non-optional)
+        owner_name = None
+        try:
+            owner_name = thread_local_data.get_user_display_name() if hasattr(
+                thread_local_data, 'get_user_display_name') else None
+        except Exception:
+            owner_name = None
+        announced = announce_presence(
+            adapter, room_id, str(uid), role,
+            owner_display_name=owner_name)
+        if not announced:
+            # Required announcement failed — leave to honor the policy.
+            try:
+                if loop and loop.is_running():
+                    asyncio.run_coroutine_threadsafe(
+                        adapter.leave_room(room_id), loop).result(timeout=15)
+                else:
+                    asyncio.run(adapter.leave_room(room_id))
+            except Exception:
+                pass
+            return (
+                f"Joined {platform}/{room_id} but could not post the "
+                f"required AI-presence announcement. Left the room to "
+                f"honor the privacy policy. Please try again."
+            )
+
+        # 5. Listen for objection
+        agent_id_for_room = f"{platform}:{room_id}"
+        def _on_detach(reason: str):
+            try:
+                if loop and loop.is_running():
+                    asyncio.run_coroutine_threadsafe(
+                        adapter.leave_room(room_id), loop).result(timeout=15)
+                else:
+                    asyncio.run(adapter.leave_room(room_id))
+            except Exception as e:
+                logger.debug("Join_External_Room: leave_room failed: %s", e)
+
+        listen_for_objection(
+            adapter, room_id, str(uid), agent_id_for_room,
+            on_detach=_on_detach)
+
+        return (
+            f"Joined {platform}/{room_id} as {role}. I posted an "
+            f"AI-presence announcement and will leave automatically if "
+            f"any participant says 'no AI' or '/agent-out'."
+        )
+    except Exception as e:
+        return f"Join_External_Room error: {str(e)[:200]}"
+
+
 def _handle_agentic_router_tool(input_text):
     """Tool handler: LLM detected a multi-step agentic task.
 
@@ -3441,6 +3630,28 @@ def get_tools(req_tool, is_first: bool = False):
                     "generic shareable link. The tool returns a URL the user can "
                     "paste into any channel; a floating share-card also appears "
                     "in chat with a one-click Copy button."
+                ),
+            ),
+            Tool(
+                name="Join_External_Room",
+                func=_handle_join_external_room_tool,
+                description=(
+                    "Join an external room/channel — Discord channel, Slack "
+                    "channel, Telegram super-group, Matrix room, Teams meeting, "
+                    "WhatsApp group, etc. — on behalf of the user as an AI "
+                    "co-pilot, note-taker, participant, silent observer, or "
+                    "writer. Use whenever the user says things like 'join my "
+                    "Discord audio room', 'attend my Teams meet', 'take notes "
+                    "in the WhatsApp family group', 'co-pilot my Slack channel', "
+                    "or similar. Always asks the user for consent first via a "
+                    "Liquid UI prompt, then announces its presence in the room "
+                    "(per HIVE AI MISSION — never silent). Leaves automatically "
+                    "if any participant says 'no AI' / '/agent-out'. Input: "
+                    "either '<platform> <room_id_or_url>' or "
+                    "'<platform> <room> <role>' or a full JSON dict "
+                    "{{\"platform\":..., \"room\":..., \"role\":...}}. Roles: "
+                    "co_pilot (default), participant, note_taker, "
+                    "silent_observer, writer."
                 ),
             ),
             Tool(
@@ -6814,6 +7025,52 @@ def chat():
                     # Fall through — do NOT return the draft standby
                     # reply; the tool-based path below will run and the
                     # VLM tool will produce a grounded answer.
+                elif (result.get('delegate') in ('local', 'hive')
+                      and not result.get('is_casual')
+                      and not result.get('is_create_agent')):
+                    # Draft self-assessed: this is a non-casual TASK
+                    # that needs more capability than the 0.8B has
+                    # (delegate='local' = bigger local model + tools;
+                    # delegate='hive' = tier escalation needed).  The
+                    # user's design intent (2026-05-07): "only if local
+                    # needs help it shd go via hive" — so try LOCAL
+                    # autogen execution first; hive escalation is
+                    # downstream via dispatch.py if the local agent
+                    # can't satisfy.
+                    #
+                    # Pre-fix this fell through to the `else` standby
+                    # reply ("I'll gather that research..."), promising
+                    # work that never happened.  Witnessed 2026-05-07
+                    # 10:24:16 with "open chrome and research AI
+                    # papers" — telemetry showed delegate='hive',
+                    # is_casual=False but reply was the draft's 102-
+                    # char polite ack and no execution kicked off.
+                    #
+                    # Setting autonomous=True (same shape as #105)
+                    # routes to:
+                    #   1. find_matching_agent (catalog 1213+ agents)
+                    #   2. If matched + recipe exists → chat_agent (REUSE)
+                    #   3. If no match → _autonomous_gather_info auto-
+                    #      fills identity (or partial-salvage at
+                    #      hart_intelligence_entry.py:5817), then
+                    #   4. recipe() runs autogen tool group locally
+                    #      (visual_execution / call_visual_task / etc).
+                    #   5. Hive escalation if step 4 can't satisfy
+                    #      (downstream in dispatch.py — separate path).
+                    app.logger.info(
+                        f"draft classifier: delegate="
+                        f"{result.get('delegate')!r} "
+                        f"is_casual=False — routing to local autogen "
+                        f"CREATE+execute (hive remains downstream "
+                        f"fallback if local can't satisfy)"
+                    )
+                    create_agent = True
+                    autonomous = True
+                    _is_agentic_orchestration = True
+                    # Fall through — do NOT return draft standby; the
+                    # create_agent branch below runs in this same
+                    # request and dispatches to find_matching_agent /
+                    # _autonomous_gather_info / recipe().
                 else:
                     return _chat_reply(
                         user_id, request_id, result['response'],

--- a/hart_intelligence_entry.py
+++ b/hart_intelligence_entry.py
@@ -2877,7 +2877,53 @@ def _handle_connect_channel_tool(input_text: str) -> str:
         )
         if register_fn is None:
             return "Channel registration is not available on this node."
-        return register_fn(channel_type, config_json)
+        result = register_fn(channel_type, config_json)
+        # Liquid UI co-pilot: when the tool reports missing-credential
+        # fields, surface a floating form via agent_ui_update so the
+        # existing AgentOverlay FormOverlay (case 'form' renderer)
+        # collects the credentials inline in chat instead of forcing
+        # the user to navigate to the admin Channels page.  The text
+        # return is preserved unchanged so the LangChain agent can
+        # summarize it to the user — the form is the IMPERATIVE next
+        # step, the text is context.  Best-effort: never raise, never
+        # block the tool return.  Same emit pattern model_orchestrator
+        # already uses (see notify_loaded line ~872).
+        try:
+            if isinstance(result, str) and 'Missing:' in result:
+                from integrations.channels.metadata import get_channel_metadata
+                meta = get_channel_metadata(channel_type) or {}
+                setup_fields = meta.get('setup_fields') or []
+                if setup_fields:
+                    from core.platform.service_registry import ServiceRegistry
+                    _lui = ServiceRegistry.get('LiquidUIService')
+                    if _lui:
+                        _lui.agent_ui_update(
+                            thread_local_data.get_user_id() or 'system',
+                            {
+                                'type': 'form',
+                                'title': f"Connect {meta.get('display_name') or channel_type}",
+                                'channel': channel_type,
+                                'fields': [
+                                    {
+                                        'name': f.get('key'),
+                                        'label': f.get('label') or f.get('key'),
+                                        'placeholder': f.get('placeholder') or '',
+                                        'secret': bool(
+                                            f.get('secret')
+                                            or (f.get('key') or '').endswith(
+                                                ('_token', '_secret', '_key'))
+                                        ),
+                                        'help': f.get('help') or '',
+                                    }
+                                    for f in setup_fields
+                                ],
+                                'submit_label': 'Connect',
+                                'submit_action': 'register_channel',
+                            },
+                        )
+        except Exception as e:
+            logger.debug("Connect_Channel: liquid UI emit skipped: %s", e)
+        return result
     except Exception as e:
         return f"Channel connect error: {str(e)[:200]}"
 

--- a/hart_intelligence_entry.py
+++ b/hart_intelligence_entry.py
@@ -2928,6 +2928,85 @@ def _handle_connect_channel_tool(input_text: str) -> str:
         return f"Channel connect error: {str(e)[:200]}"
 
 
+def _handle_invite_friend_tool(input_text: str) -> str:
+    """Generate a shareable Nunba invite link the user can send to a friend.
+
+    Mirrors the _handle_connect_channel_tool pattern (G1, plan
+    elegant-spinning-avalanche).  Reuses the canonical referral primitive
+    ``DistributionService.get_or_create_referral_code`` (idempotent —
+    same user → same code) and the canonical URL builder
+    ``invite_share_url`` so the link format stays a single-writer.
+
+    Input formats:
+      - "" (empty) — generic "share with anyone" link
+      - "<context, e.g. 'work friend' or 'family'>" — same link, just
+        echoed back in the friendly reply for the LLM to weave in
+
+    Returns text including the share URL so the LangChain agent can
+    summarize for the user.  Also fires a Liquid UI ``form`` card via
+    ``agent_ui_update`` (same emit pattern as Connect_Channel) so the
+    AgentOverlay renders an inline floating share-card with copy +
+    "share via channel" actions.
+    """
+    try:
+        uid = thread_local_data.get_user_id()
+        if not uid:
+            return "Cannot generate invite — no signed-in user in this session."
+        from integrations.social.distribution_service import (
+            DistributionService, invite_share_url,
+        )
+        from integrations.social.models import get_db
+        db = get_db()
+        try:
+            ref = DistributionService.get_or_create_referral_code(db, str(uid))
+            db.commit()
+        finally:
+            db.close()
+        code = ref.get('code') or ''
+        if not code:
+            return "Failed to generate invite code — please try again."
+        url = invite_share_url(code)
+
+        # Liquid UI co-pilot: emit a share card so the user can copy /
+        # send the link with one click.  Same pattern Connect_Channel
+        # uses (line 2891-2925), same canonical AgentOverlay 'form'
+        # renderer.  Best-effort — never blocks the tool return.
+        try:
+            from core.platform.service_registry import ServiceRegistry
+            _lui = ServiceRegistry.get('LiquidUIService')
+            if _lui:
+                _lui.agent_ui_update(
+                    str(uid),
+                    {
+                        'type': 'form',
+                        'title': 'Share invite',
+                        'channel': 'invite',
+                        'fields': [
+                            {
+                                'name': 'invite_url',
+                                'label': 'Your invite link',
+                                'value': url,
+                                'readonly': True,
+                            },
+                        ],
+                        'submit_label': 'Copy link',
+                        'submit_action': 'copy_invite_url',
+                    },
+                )
+        except Exception as e:
+            logger.debug("Invite_Friend: liquid UI emit skipped: %s", e)
+
+        context_hint = (input_text or '').strip()
+        suffix = f" (context: {context_hint})" if context_hint else ""
+        return (
+            f"Here is your shareable invite link: {url}{suffix}. "
+            f"Send it via any channel — anyone who joins via this link "
+            f"is credited as your referral."
+        )
+    except Exception as e:
+        return f"Invite_Friend error: {str(e)[:200]}"
+
+
 def _handle_agentic_router_tool(input_text):
     """Tool handler: LLM detected a multi-step agentic task.
 
@@ -3345,6 +3424,23 @@ def get_tools(req_tool, is_first: bool = False):
                     "authentication flow. Do NOT ask the user for credentials first — "
                     "call this tool with just the channel name and it will tell you "
                     "what's needed."
+                ),
+            ),
+            Tool(
+                name="Invite_Friend",
+                func=_handle_invite_friend_tool,
+                description=(
+                    "Generate a shareable Nunba invite link the user can send to a "
+                    "friend, colleague, or family member so they can join Nunba "
+                    "and (optionally) credit the inviter as their referrer. Use "
+                    "whenever the user says things like 'invite a friend', 'share "
+                    "Nunba with my colleague', 'give me an invite link', 'how do "
+                    "I refer people', 'send my friend an invite', or similar. "
+                    "Input: optional short context describing who the invite is "
+                    "for (e.g. 'work friend', 'family'), or empty string for a "
+                    "generic shareable link. The tool returns a URL the user can "
+                    "paste into any channel; a floating share-card also appears "
+                    "in chat with a one-click Copy button."
                 ),
             ),
             Tool(

--- a/hartos_bootstrap.py
+++ b/hartos_bootstrap.py
@@ -199,6 +199,7 @@ def _run_bootstrap(app, cfg: dict) -> None:
             _init_database(cfg)
             _init_channel_adapters(app, cfg)
             _init_agent_engine_subsystem(app)
+            _init_livekit_supervisor(cfg)
             _run_on_bootstrap_complete(cfg)
         finally:
             if bypass_active:
@@ -490,6 +491,39 @@ def _init_agent_engine_subsystem(app) -> None:
         logger.info("Agent engine initialised")
     except Exception as e:
         logger.warning(f"Agent engine init failed: {e}")
+
+
+# ─── Step 8b: LiveKit SFU supervisor (regional/flat only) ────────────
+
+
+def _init_livekit_supervisor(cfg: dict) -> None:
+    """Spawn the embedded LiveKit SFU on regional/flat HARTOS nodes.
+
+    Architecture intent: PeerLink + WebRTC mesh handle ≤4-participant
+    calls (P2P, no SFU).  LiveKit is the FALLBACK SFU for >4-participant
+    calls and AgentVoiceBridge rendezvous, hosted by regional nodes for
+    their tenants.  Central HARTOS does NOT run an SFU (sync /
+    federation / backup-restore only) — the supervisor short-circuits
+    when ``HEVOLVE_DEPLOY_MODE=central`` or ``LIVEKIT_DISABLE=1``.
+
+    Idempotent: subsequent calls return the same supervisor instance.
+    Failure to start logs a warning but never aborts bootstrap; clients
+    fall back to P2P mesh until the SFU is reachable.
+    """
+    try:
+        from integrations.social.livekit_supervisor import start_supervisor
+        info = start_supervisor()
+        if info.get('should_run'):
+            logger.info(
+                "LiveKit supervisor: %s (running=%s, url=%s, binary=%s)",
+                info.get('mode'), info.get('running'),
+                info.get('url'), info.get('binary_path'))
+        else:
+            logger.info(
+                "LiveKit supervisor: skipped (%s) — calls use P2P mesh",
+                info.get('reason') or info.get('mode'))
+    except Exception as e:
+        logger.warning(f"LiveKit supervisor init failed: {e}")
 
 
 # ─── Step 9: on_bootstrap_complete consumer callback ─────────────────

--- a/integrations/agent_engine/agent_daemon.py
+++ b/integrations/agent_engine/agent_daemon.py
@@ -552,7 +552,15 @@ class AgentDaemon:
             if not goals:
                 return
 
-            idle_agents = IdleDetectionService.get_idle_opted_in_agents(db)
+            # Use ``get_idle_agent_personas`` — agent-type users (Echo,
+            # Quest, Contest Curator, …) eligible for goal dispatch.
+            # Do NOT use ``get_idle_opted_in_agents`` here: that filter
+            # is the human-consent privacy gate for distributed compute
+            # sharing, not the agent-persona gate.  Mismatch silently
+            # returned [] on installs where no human had opted in →
+            # daemon stalled with seeded personas never dispatching
+            # (root-cause logged 2026-05-01).
+            idle_agents = IdleDetectionService.get_idle_agent_personas(db)
             if not idle_agents:
                 return
 

--- a/integrations/agent_engine/liquid_ui_service.py
+++ b/integrations/agent_engine/liquid_ui_service.py
@@ -66,6 +66,15 @@ COMPONENT_TYPES = {
     'agent_action': {'props': ['agent_id', 'action_type', 'description',
                                'status', 'result', 'timestamp']},
     'navigate': {'props': ['target', 'params', 'transition']},
+    # ── External-room copilot (UNIF-G5) ──
+    # Live transcript + decisions + action items for an external Discord
+    # audio room / Teams meet / WhatsApp group voice / Reddit voice room
+    # joined via UNIF-G2 Join_External_Room.  Idempotent overwrite — backend
+    # emits the FULL state on every transcript chunk; frontend replaces.
+    'meet_copilot': {'props': ['call_id', 'platform', 'room_id', 'state',
+                               'transcript_lines', 'decisions',
+                               'action_items', 'participants',
+                               'agent_role']},
 }
 
 # ═══════════════════════════════════════════════════════════════

--- a/integrations/agent_engine/speculative_dispatcher.py
+++ b/integrations/agent_engine/speculative_dispatcher.py
@@ -456,15 +456,18 @@ class SpeculativeDispatcher:
             (parsed.get('channel_connect') or '').strip()
             or parsed.get('is_create_agent')
             or (parsed.get('language_change') or '').strip()
+            or (parsed.get('invite_intent') or '').strip()
         ):
             logger.info(
                 "draft-first: actionable intent flag set "
                 "(channel_connect=%r, is_create_agent=%r, "
-                "language_change=%r) — escalating delegate=none → "
-                "'local' so the expert tool registry handles the turn.",
+                "language_change=%r, invite_intent=%r) — escalating "
+                "delegate=none → 'local' so the expert tool registry "
+                "handles the turn.",
                 parsed.get('channel_connect'),
                 parsed.get('is_create_agent'),
                 parsed.get('language_change'),
+                parsed.get('invite_intent'),
             )
             draft_reply = _REFUSAL_STANDBY_REPLY
             delegate = 'local'
@@ -793,6 +796,7 @@ class SpeculativeDispatcher:
             '"is_create_agent": true OR false, '
             '"channel_connect": "<channel name or empty string>", '
             '"language_change": "<ISO 639-1 code or empty string>", '
+            '"invite_intent": "<short context if user wants invite link, or empty>", '
             '"reason": "<why you chose this delegate value>"}\n\n'
             # ── delegate ────────────────────────────────────────────────
             "delegate: Use \"none\" for greetings, small-talk, factual "
@@ -839,7 +843,16 @@ class SpeculativeDispatcher:
             "Otherwise use an empty string \"\". This overrides the "
             "session's preferred_lang so the main LLM responds in "
             "the requested language and TTS routes to an engine that "
-            "supports it."
+            "supports it.\n\n"
+            # ── invite_intent ───────────────────────────────────────────
+            "invite_intent: if the user is asking to invite, share, or "
+            "refer a friend / colleague / family member to Nunba (e.g. "
+            "\"invite a friend\", \"give me an invite link\", \"share "
+            "Nunba with my colleague\", \"how do I refer people\"), put "
+            "a short freeform context here (e.g. \"work friend\" or "
+            "\"family\") — empty string is fine for a generic shareable "
+            "link. Otherwise use an empty string \"\". This routes the "
+            "turn to the Invite_Friend tool."
         )
 
     def _track_call_telemetry(

--- a/integrations/agent_engine/speculative_dispatcher.py
+++ b/integrations/agent_engine/speculative_dispatcher.py
@@ -457,17 +457,19 @@ class SpeculativeDispatcher:
             or parsed.get('is_create_agent')
             or (parsed.get('language_change') or '').strip()
             or (parsed.get('invite_intent') or '').strip()
+            or (parsed.get('join_room_intent') or '').strip()
         ):
             logger.info(
                 "draft-first: actionable intent flag set "
                 "(channel_connect=%r, is_create_agent=%r, "
-                "language_change=%r, invite_intent=%r) — escalating "
-                "delegate=none → 'local' so the expert tool registry "
-                "handles the turn.",
+                "language_change=%r, invite_intent=%r, "
+                "join_room_intent=%r) — escalating delegate=none → "
+                "'local' so the expert tool registry handles the turn.",
                 parsed.get('channel_connect'),
                 parsed.get('is_create_agent'),
                 parsed.get('language_change'),
                 parsed.get('invite_intent'),
+                parsed.get('join_room_intent'),
             )
             draft_reply = _REFUSAL_STANDBY_REPLY
             delegate = 'local'
@@ -797,6 +799,7 @@ class SpeculativeDispatcher:
             '"channel_connect": "<channel name or empty string>", '
             '"language_change": "<ISO 639-1 code or empty string>", '
             '"invite_intent": "<short context if user wants invite link, or empty>", '
+            '"join_room_intent": "<platform + room/url if user wants agent to join, or empty>", '
             '"reason": "<why you chose this delegate value>"}\n\n'
             # ── delegate ────────────────────────────────────────────────
             "delegate: Use \"none\" for greetings, small-talk, factual "
@@ -852,7 +855,18 @@ class SpeculativeDispatcher:
             "a short freeform context here (e.g. \"work friend\" or "
             "\"family\") — empty string is fine for a generic shareable "
             "link. Otherwise use an empty string \"\". This routes the "
-            "turn to the Invite_Friend tool."
+            "turn to the Invite_Friend tool.\n\n"
+            # ── join_room_intent ────────────────────────────────────────
+            "join_room_intent: if the user is asking the AI to JOIN an "
+            "external room / channel / meeting / group as a co-pilot, "
+            "note-taker, or participant (e.g. \"join my Discord audio "
+            "room\", \"attend my Teams meet\", \"take notes in the "
+            "WhatsApp family group\", \"co-pilot my Slack channel\"), "
+            "put a short \"<platform> <room or url>\" string here "
+            "(e.g. \"discord https://discord.com/channels/123/456\"). "
+            "Otherwise use an empty string \"\". This routes the turn "
+            "to the Join_External_Room tool, which always gates on "
+            "consent and announces the agent's presence in the room."
         )
 
     def _track_call_telemetry(

--- a/integrations/agent_engine/speculative_dispatcher.py
+++ b/integrations/agent_engine/speculative_dispatcher.py
@@ -432,6 +432,43 @@ class SpeculativeDispatcher:
             )
             delegate = 'local'
 
+        # ACTIONABLE-INTENT GUARD: when the draft's own classifier
+        # surfaces an actionable intent flag (channel_connect,
+        # is_create_agent, language_change), answering in-band would
+        # orphan the action — there is no way to invoke the matching
+        # tool (Connect_Channel / Create_Agent) from the casual draft
+        # path because casual_conv=True skips the full tool registry
+        # in hart_intelligence_entry.get_ans (see the is_first=True
+        # branch).  Promote delegate=none → 'local' so the expert
+        # turn binds the full registry — Connect_Channel for
+        # channel-add intents, Create_Agent for agent-build intents —
+        # and actually fires the tool the LLM would otherwise have
+        # described in free-form text.
+        #
+        # The draft's reply is also replaced with the standby (same
+        # rationale as REFUSAL GUARD above): the draft on the
+        # casual path has no tool access, so any in-band reply on
+        # an actionable-intent turn is a verified-signal anti-pattern
+        # — it claims action while taking none.  The expert reply
+        # replaces the standby via the existing speculation_id
+        # bubble-replacement path (#204 already shipped).
+        if delegate == 'none' and (
+            (parsed.get('channel_connect') or '').strip()
+            or parsed.get('is_create_agent')
+            or (parsed.get('language_change') or '').strip()
+        ):
+            logger.info(
+                "draft-first: actionable intent flag set "
+                "(channel_connect=%r, is_create_agent=%r, "
+                "language_change=%r) — escalating delegate=none → "
+                "'local' so the expert tool registry handles the turn.",
+                parsed.get('channel_connect'),
+                parsed.get('is_create_agent'),
+                parsed.get('language_change'),
+            )
+            draft_reply = _REFUSAL_STANDBY_REPLY
+            delegate = 'local'
+
         # Non-Latin languages skip draft entirely (hart_intelligence_entry.py)
         # so this code path is only reached for English/Latin-script languages.
 

--- a/integrations/channels/discord_adapter.py
+++ b/integrations/channels/discord_adapter.py
@@ -42,11 +42,12 @@ from .base import (
     ChannelSendError,
     ChannelRateLimitError,
 )
+from .room_capable import RoomCapableAdapter, UnsupportedRoomError
 
 logger = logging.getLogger(__name__)
 
 
-class DiscordAdapter(ChannelAdapter):
+class DiscordAdapter(ChannelAdapter, RoomCapableAdapter):
     """
     Discord messaging adapter.
 
@@ -55,6 +56,18 @@ class DiscordAdapter(ChannelAdapter):
         adapter = DiscordAdapter(config)
         adapter.on_message(my_handler)
         await adapter.start()
+
+    Room semantics (UNIF-G2 ``RoomCapableAdapter``):
+        Discord text channels — bot is auto-member of every channel
+        in the guilds it has been invited to; ``join_room`` validates
+        access + caches the room id for downstream filtering.
+
+        Discord voice channels — ``join_room`` opens a ``VoiceClient``
+        via ``voice_channel.connect()`` so the bot is visibly present.
+        The audio-receive path (frames → STT) is wired in
+        ``agent_voice_bridge._tick()`` (UNIF-G3 / W1.2).
+
+        DMs — raises ``UnsupportedRoomError`` (DMs aren't rooms).
     """
 
     def __init__(self, config: ChannelConfig):
@@ -72,12 +85,24 @@ class DiscordAdapter(ChannelAdapter):
         intents.members = True
         intents.dm_messages = True
         intents.guild_messages = True
+        intents.voice_states = True  # UNIF-G2: voice room presence + member listing
 
         self._bot = commands.Bot(
             command_prefix=config.extra.get("prefix", "!"),
             intents=intents,
         )
         self._bot_user_id: Optional[int] = None
+        # UNIF-G2: per-room voice-client registry.  Keyed by Discord
+        # voice-channel id (int).  Populated by ``join_room`` for voice
+        # channels, drained by ``leave_room``.  Only voice channels live
+        # here — text channels are presence-by-default.
+        self._voice_clients: Dict[int, Any] = {}
+        # UNIF-G2: text-room "presence" registry.  Discord doesn't have
+        # an explicit join handshake for text channels (the bot is a
+        # member of every guild text channel it can see), so we track
+        # the bot's deliberate-presence intent locally for downstream
+        # callers (e.g. message-filtering, leave_room semantics).
+        self._joined_text_rooms: set = set()
         self._setup_events()
 
     @property
@@ -408,6 +433,170 @@ class DiscordAdapter(ChannelAdapter):
         except Exception as e:
             logger.error(f"Failed to create thread: {e}")
             return None
+
+    # ─── UNIF-G2: RoomCapableAdapter implementation ──────────────────
+
+    async def _resolve_channel(self, room_id: str):
+        """Best-effort channel resolve — cache → REST fallback.
+
+        Returns the discord channel object or ``None`` if it can't be
+        found (deleted / wrong id / no access).  Centralized so
+        ``join_room``/``leave_room``/``list_room_members`` share the
+        same lookup path instead of duplicating ``get_channel``+fallback
+        ladder three times.
+        """
+        try:
+            cid = int(room_id)
+        except (TypeError, ValueError):
+            return None
+        channel = self._bot.get_channel(cid)
+        if channel is not None:
+            return channel
+        try:
+            return await self._bot.fetch_channel(cid)
+        except discord.NotFound:
+            return None
+        except discord.Forbidden:
+            return None
+        except Exception as e:
+            logger.error(f"Discord _resolve_channel({cid}) failed: {e}")
+            return None
+
+    async def join_room(self, room_id: str,
+                        role: str = 'participant') -> bool:
+        """Join a Discord channel/room as the agent's presence.
+
+        - Text channel → validate access, cache presence intent, return True.
+        - Voice channel → connect via ``VoiceClient`` so the bot is
+          visibly in the call.  Audio frames are picked up later by
+          ``agent_voice_bridge._tick()`` (UNIF-G3 / W1.2 wiring).
+        - DM (no guild) → raise ``UnsupportedRoomError``.
+        - Channel not found / forbidden → return False.
+
+        Idempotent on (room_id) — calling twice does NOT double-join
+        a voice channel; the cached client is returned.
+        """
+        channel = await self._resolve_channel(room_id)
+        if channel is None:
+            logger.warning(
+                "Discord.join_room: channel %s not found / forbidden",
+                room_id)
+            return False
+
+        if isinstance(channel, discord.DMChannel):
+            raise UnsupportedRoomError(
+                "Discord DMs are not rooms — use send_message for 1:1.")
+
+        if isinstance(channel, discord.VoiceChannel):
+            cid = int(room_id)
+            existing = self._voice_clients.get(cid)
+            if existing is not None and existing.is_connected():
+                return True
+            try:
+                voice_client = await channel.connect(reconnect=True,
+                                                    self_deaf=False)
+                self._voice_clients[cid] = voice_client
+                logger.info(
+                    "Discord.join_room: voice channel %s connected (role=%s)",
+                    cid, role)
+                return True
+            except discord.ClientException as e:
+                # Already connected from another path — treat as success.
+                logger.info(
+                    "Discord.join_room: voice %s already-connected (%s)",
+                    cid, e)
+                return True
+            except (discord.opus.OpusNotLoaded, AttributeError) as e:
+                logger.warning(
+                    "Discord.join_room: opus library unavailable for "
+                    "voice %s (%s); voice presence requires libopus on "
+                    "the host", cid, e)
+                return False
+            except Exception as e:
+                logger.error(
+                    "Discord.join_room: voice connect failed for %s: %s",
+                    cid, e)
+                return False
+
+        # Text channel / thread / news / forum / stage etc. — Discord
+        # doesn't expose an explicit "join" for non-voice channels, but
+        # we record presence-intent so leave_room is symmetric.
+        self._joined_text_rooms.add(int(room_id))
+        logger.info(
+            "Discord.join_room: text room %s presence cached (role=%s)",
+            room_id, role)
+        return True
+
+    async def leave_room(self, room_id: str) -> bool:
+        """Leave a Discord channel/room.
+
+        - Voice channel → disconnect the cached ``VoiceClient``.
+        - Text channel → drop the cached presence intent.
+        - Unknown / never-joined → return False (caller decides whether
+          that's a problem).
+        """
+        try:
+            cid = int(room_id)
+        except (TypeError, ValueError):
+            return False
+
+        # Voice path
+        voice_client = self._voice_clients.pop(cid, None)
+        if voice_client is not None:
+            try:
+                if voice_client.is_connected():
+                    await voice_client.disconnect(force=False)
+                logger.info("Discord.leave_room: voice %s disconnected", cid)
+                return True
+            except Exception as e:
+                logger.error(
+                    "Discord.leave_room: voice disconnect %s failed: %s",
+                    cid, e)
+                return False
+
+        # Text path
+        if cid in self._joined_text_rooms:
+            self._joined_text_rooms.discard(cid)
+            logger.info("Discord.leave_room: text %s presence cleared", cid)
+            return True
+
+        logger.debug("Discord.leave_room: %s not in joined registry", cid)
+        return False
+
+    async def list_room_members(self, room_id: str) -> List[Dict[str, Any]]:
+        """List members of a Discord channel/voice channel.
+
+        Text channels — uses ``channel.members`` (requires GUILD_MEMBERS
+        intent, which we declare).  Voice channels — uses
+        ``channel.members`` populated from voice-state cache.
+
+        Returns ``[]`` on any error / unknown channel; callers shouldn't
+        rely on member listing being authoritative.
+        """
+        channel = await self._resolve_channel(room_id)
+        if channel is None:
+            return []
+        members_attr = getattr(channel, 'members', None)
+        if not members_attr:
+            return []
+        result: List[Dict[str, Any]] = []
+        try:
+            for m in members_attr:
+                # Skip the bot itself in member listings — caller asked
+                # who else is here.
+                if m.id == self._bot_user_id:
+                    continue
+                result.append({
+                    'id': str(m.id),
+                    'display_name': getattr(m, 'display_name', None) or m.name,
+                    'is_bot': bool(getattr(m, 'bot', False)),
+                })
+        except Exception as e:
+            logger.error(
+                "Discord.list_room_members: iterating %s failed: %s",
+                room_id, e)
+            return []
+        return result
 
 
 def create_discord_adapter(token: str = None, **kwargs) -> DiscordAdapter:

--- a/integrations/channels/room_capable.py
+++ b/integrations/channels/room_capable.py
@@ -1,0 +1,129 @@
+"""
+room_capable — UNIF-G2 — opt-in mixin marking adapters that support
+room/channel join semantics.
+
+Why a Mixin and not a base-class extension:
+   Not every channel concept supports rooms (SMS / email / iMessage 1:1
+   / signal 1:1 don't).  Adding ``join_room`` to ``ChannelAdapter`` would
+   force those adapters to raise ``UnsupportedRoomError`` from a method
+   they have no business implementing.  A separate Mixin keeps
+   ``ChannelAdapter`` minimal (single-responsibility) and lets G2's
+   ``Join_External_Room`` agent tool detect support via
+   ``isinstance(adapter, RoomCapableAdapter)``.
+
+Adapters that should subclass this Mixin (alongside ``ChannelAdapter``):
+   - DiscordAdapter (text channels + voice rooms via livekit bridge)
+   - SlackAdapter (channels)
+   - MatrixAdapter (rooms)
+   - TelegramAdapter (super-groups + channels)
+   - TeamsAdapter (channels + meetings)
+   - WhatsAppAdapter (groups)
+
+Adapters that should NOT subclass this Mixin:
+   - SignalAdapter (1:1 only at the protocol level we use today)
+   - IMessageAdapter (1:1 only via current bridge)
+   - WebAdapter (per-user web chat, no rooms)
+   - EmailAdapter (threads, not rooms)
+   - VoiceAdapter (per-call, not rooms)
+   - SMSAdapter (1:1)
+
+Voice rooms (Discord audio, Teams meet, Zoom-style) route through the
+canonical ``LiveKitService.issue_token`` + ``AgentVoiceBridge.attach_agent``
+pair (see ``integrations/social/agent_voice_bridge.py``).  The adapter's
+``join_room`` is for TEXT room-membership only; voice participation is
+livekit-side.
+
+Per-platform implementation notes are deferred to each adapter — this
+module only declares the contract.  The contract is a SUBSET of
+``ChannelAdapter`` so a class can ``extend`` either order:
+   ``class DiscordAdapter(ChannelAdapter, RoomCapableAdapter): ...``
+
+Per HIVE AI MISSION: G2's ``Join_External_Room`` tool ALWAYS calls
+``room_presence_service.gate(...)`` BEFORE ``join_room(...)`` and
+``announce_presence(...)`` IMMEDIATELY AFTER a successful join.
+``join_room`` itself is the platform-specific transport — never the
+policy point.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+class UnsupportedRoomError(Exception):
+    """Raised when a caller tries to join a room on an adapter that does
+    not support rooms (e.g. SMS).  Caught by the Join_External_Room tool
+    so it can return a graceful "this platform doesn't support rooms"
+    message instead of a stack trace."""
+
+
+class RoomCapableAdapter:
+    """Mixin marker for channel adapters that support room/channel join
+    semantics.
+
+    Subclasses MUST override ``join_room``, ``leave_room``, and
+    ``list_room_members`` (per platform).  All three are async because
+    every existing channel adapter uses asyncio and ``ChannelAdapter``
+    is async-first.
+
+    Roles passed to ``join_room`` are the SAME role strings used by
+    ``room_presence_service`` so consent + adapter speak the same
+    vocabulary:
+       - ``co_pilot`` — full read+write+react participation
+       - ``participant`` — full read+write
+       - ``note_taker`` — read+react only (no write)
+       - ``silent_observer`` — read only
+       - ``writer`` — write-on-behalf only (uncommon — usually paired
+         with another role)
+    """
+
+    async def join_room(self, room_id: str,
+                        role: str = 'participant') -> bool:
+        """Join the named room/channel as the agent's presence.
+
+        Args:
+            room_id: Platform-native room id (e.g. Discord channel id,
+                     Slack channel id, Matrix room id, Telegram chat id).
+            role:    One of the role strings above.  Adapters MAY use
+                     this to set platform-side permissions (e.g. mute
+                     for ``silent_observer``).
+
+        Returns ``True`` iff the join succeeded.  Adapters that fail
+        for transient reasons (rate limit, network) should return
+        ``False`` rather than raise — the Join_External_Room tool
+        handles the retry / fallback on the caller side.
+
+        Adapters MUST raise ``UnsupportedRoomError`` if the protocol
+        cannot represent room membership (e.g. attempting to join a
+        DM "room").
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} subclasses RoomCapableAdapter "
+            f"but does not implement join_room")
+
+    async def leave_room(self, room_id: str) -> bool:
+        """Leave the named room/channel.  Counterpart to ``join_room``."""
+        raise NotImplementedError(
+            f"{type(self).__name__} subclasses RoomCapableAdapter "
+            f"but does not implement leave_room")
+
+    async def list_room_members(self, room_id: str) -> List[Dict[str, Any]]:
+        """Return a list of member dicts for the room.
+
+        Each dict at minimum contains ``id`` and ``display_name``.
+        Adapters MAY include additional platform-specific fields.
+        Optional — implementations may return ``[]`` if listing is not
+        supported or rate-limited.
+        """
+        return []
+
+
+def is_room_capable(adapter: Any) -> bool:
+    """Return True iff ``adapter`` supports room operations.
+
+    Convenience helper used by ``Join_External_Room`` so the agent tool
+    can return a clean "platform support pending" message for adapters
+    that haven't been wired with the Mixin yet, without paying the cost
+    of a try/except around the actual join.
+    """
+    return isinstance(adapter, RoomCapableAdapter)

--- a/integrations/coding_agent/idle_detection.py
+++ b/integrations/coding_agent/idle_detection.py
@@ -79,57 +79,110 @@ class IdleDetectionService:
         return True
 
     @staticmethod
-    def get_idle_opted_in_agents(db: Session) -> List[Dict]:
-        """Get all idle agents that have opted in to distributed coding.
+    def _check_user_dispatchable(user) -> bool:
+        """Shared dispatchability check: not admin-paused AND no active sessions.
 
-        Agents with ``settings.paused == True`` (set via /api/admin/agents/<id>/pause)
-        are excluded so an admin-paused agent truly stops receiving work.  This is
-        the single enforcement point — no parallel path (Gate 4 / CLAUDE.md).
+        Used by BOTH ``get_idle_opted_in_agents`` (distributed-compute
+        privacy contract) AND ``get_idle_agent_personas`` (local agent
+        goal dispatch).  Single canonical idle-check — no parallel
+        paths (Gate 4 / CLAUDE.md).
+
+        Returns True if the user is eligible to receive work right now.
+        """
+        # Skip admin-paused entirely.  The `settings` JSON column is
+        # the single source of truth; /api/admin/agents/<id>/pause
+        # writes it, /resume clears it.
+        user_settings = user.settings or {}
+        if user_settings.get('paused') is True:
+            return False
+        # Worker-thread guard (same rationale as ``is_agent_idle``):
+        # consult sys.modules instead of ``from create_recipe import …``.
+        # If create_recipe isn't loaded yet, treat sessions as idle —
+        # same fall-through the original ImportError branch used.  Main
+        # thread loads create_recipe lazily; once that finishes,
+        # subsequent ticks see a populated ``user_tasks`` and the
+        # all_idle gate runs as designed.
+        cr_mod = sys.modules.get('create_recipe')
+        user_tasks = getattr(cr_mod, 'user_tasks', None) if cr_mod else None
+        if user_tasks is None:
+            return True
+        user_sessions = [k for k in user_tasks.keys()
+                         if k.startswith(f'{user.id}_')]
+        if not user_sessions:
+            return True
+        return all(
+            IdleDetectionService.is_agent_idle(s) for s in user_sessions
+        )
+
+    @staticmethod
+    def _user_to_dict(user) -> Dict:
+        """Project a User row into the dict shape both consumers expect."""
+        return {
+            'user_id': user.id,
+            'username': user.username,
+            'user_type': user.user_type,
+        }
+
+    @staticmethod
+    def get_idle_opted_in_agents(db: Session) -> List[Dict]:
+        """Get all idle users who have OPTED IN to distributed coding.
+
+        **Intent (privacy contract):** humans who explicitly toggled
+        ``idle_compute_opt_in=True`` consent to having their idle
+        compute used by other Hive nodes.  This is the canonical
+        eligibility filter for:
+
+        - ``coding_daemon._loop`` — peer compute sharing
+        - ``peer_discovery._self_info`` — gossip advertising of
+          available idle capacity
+
+        **Do NOT use this for local agent_daemon goal dispatch** —
+        that wants ``get_idle_agent_personas`` instead, which dispatches
+        goals to ``user_type='agent'`` rows (Echo, Quest, etc.) without
+        gating on the human-consent flag they don't apply to.
         """
         from integrations.social.models import User
-
         opted_in = db.query(User).filter(
             User.idle_compute_opt_in == True,
         ).all()
+        return [
+            IdleDetectionService._user_to_dict(u)
+            for u in opted_in
+            if IdleDetectionService._check_user_dispatchable(u)
+        ]
 
-        idle_agents = []
-        for user in opted_in:
-            # Skip admin-paused agents entirely.  The `settings` JSON column is
-            # the single source of truth; /api/admin/agents/<id>/pause writes it,
-            # /resume clears it.
-            user_settings = user.settings or {}
-            if user_settings.get('paused') is True:
-                continue
-            # Worker-thread guard (same rationale as is_agent_idle above):
-            # consult sys.modules instead of `from create_recipe import …`.
-            # If create_recipe isn't loaded yet, treat the user's sessions
-            # as idle (same fall-through the original ImportError branch
-            # used).  The main-thread bootstrap loads create_recipe lazily
-            # — once that finishes, subsequent ticks see a populated
-            # user_tasks and the all_idle gate runs as designed.
-            cr_mod = sys.modules.get('create_recipe')
-            user_tasks = getattr(cr_mod, 'user_tasks', None) if cr_mod else None
-            if user_tasks is None:
-                idle_agents.append({
-                    'user_id': user.id,
-                    'username': user.username,
-                    'user_type': user.user_type,
-                })
-                continue
-            # Sessions are keyed as f'{user_id}_{prompt_id}'
-            user_sessions = [k for k in user_tasks.keys()
-                             if k.startswith(f'{user.id}_')]
-            all_idle = all(
-                IdleDetectionService.is_agent_idle(s) for s in user_sessions
-            ) if user_sessions else True
-            if all_idle:
-                idle_agents.append({
-                    'user_id': user.id,
-                    'username': user.username,
-                    'user_type': user.user_type,
-                })
+    @staticmethod
+    def get_idle_agent_personas(db: Session) -> List[Dict]:
+        """Get all idle ``user_type='agent'`` personas eligible for goal dispatch.
 
-        return idle_agents
+        **Intent:** the agent_daemon dispatches goals (Echo's marketing
+        explainer, Quest's contest recap, Contest Curator's idea
+        capture, …) to autonomous agent personas.  Those personas are
+        DB rows with ``user_type='agent'`` — they exist *to* do work.
+        There is no human to consent on their behalf, so the
+        ``idle_compute_opt_in`` flag (which gates distributed-compute
+        sharing for humans) does NOT apply.
+
+        Eligibility rules:
+          1. ``user_type == 'agent'``
+          2. NOT admin-paused (``settings.paused != True``)
+          3. No active non-terminated sessions (``is_agent_idle`` true)
+
+        Captured 2026-05-01 root-cause: previously the daemon called
+        ``get_idle_opted_in_agents``, which silently returned `[]` on
+        installs where no user had toggled the human consent flag —
+        the seeded marketing personas (Echo/Quest/Contest Curator)
+        never dispatched because they weren't gated by the right flag.
+        """
+        from integrations.social.models import User
+        agent_users = db.query(User).filter(
+            User.user_type == 'agent',
+        ).all()
+        return [
+            IdleDetectionService._user_to_dict(u)
+            for u in agent_users
+            if IdleDetectionService._check_user_dispatchable(u)
+        ]
 
     @staticmethod
     def opt_in(db: Session, user_id: str) -> Dict:

--- a/integrations/mcp/mcp_http_bridge.py
+++ b/integrations/mcp/mcp_http_bridge.py
@@ -547,18 +547,15 @@ def _tool_create_goal(goal_type: str, title: str, description: str = '', spark_b
 
 
 def _tool_agent_status() -> str:
-    """Check agent daemon health, active dispatches, and system state."""
-    from core.port_registry import get_port
-    from core.http_pool import pooled_get
-    status = {
-        "daemon_enabled": os.environ.get('HEVOLVE_AGENT_ENGINE_ENABLED', 'false'),
-        "poll_interval": int(os.environ.get('HEVOLVE_AGENT_POLL_INTERVAL', '30')),
-    }
-    try:
-        resp = pooled_get(f'http://localhost:{get_port("llm")}/health', timeout=2)
-        status['llm_server'] = 'running' if resp.status_code == 200 else f'status {resp.status_code}'
-    except Exception:
-        status['llm_server'] = 'not reachable'
+    """Check agent daemon health, active dispatches, and system state.
+
+    Uses ``core.health_probe`` canonical probes — never reads env-var
+    snapshots or hardcoded ports.  See module docstring there for the
+    root-cause notes from the 2026-05-01 false-negative incident.
+    """
+    from core.health_probe import probe_agent_daemon, probe_llm
+    status = probe_agent_daemon()
+    status['llm_server'] = probe_llm()
     try:
         reg = _get_registry()
         status['expert_agents'] = len(reg.agents)
@@ -618,19 +615,11 @@ def _tool_list_recipes() -> str:
 
 def _tool_system_health() -> str:
     """Full system health check: Flask server, LLM, DB, memory graph."""
-    from core.port_registry import get_port
-    from core.http_pool import pooled_get
-    health = {}
-    try:
-        resp = pooled_get(f'http://localhost:{get_port("backend")}/status', timeout=2)
-        health['backend'] = {'status': 'up', 'code': resp.status_code}
-    except Exception:
-        health['backend'] = {'status': 'down'}
-    try:
-        resp = pooled_get(f'http://localhost:{get_port("llm")}/health', timeout=2)
-        health['llm'] = {'status': 'up', 'code': resp.status_code}
-    except Exception:
-        health['llm'] = {'status': 'down'}
+    from core.health_probe import probe_nunba_flask, probe_llm
+    health = {
+        'backend': probe_nunba_flask(),
+        'llm': probe_llm(),
+    }
     try:
         db = _get_db()
         try:

--- a/integrations/mcp/mcp_server.py
+++ b/integrations/mcp/mcp_server.py
@@ -205,29 +205,21 @@ def dispatch_goal(goal_id: str, goal_type: str = 'marketing') -> str:
 
 @mcp.tool()
 def agent_status() -> str:
-    """Check agent daemon health, active dispatches, and system state."""
-    status = {
-        "daemon_enabled": os.environ.get('HEVOLVE_AGENT_ENGINE_ENABLED', 'false'),
-        "poll_interval": int(os.environ.get('HEVOLVE_AGENT_POLL_INTERVAL', '30')),
-        "max_concurrent": int(os.environ.get('HEVOLVE_AGENT_MAX_CONCURRENT', '10')),
-        "speculative_enabled": os.environ.get('HEVOLVE_SPECULATIVE_ENABLED', 'false'),
-    }
+    """Check agent daemon health, active dispatches, and system state.
 
-    # Check running server
-    try:
-        resp = pooled_get('http://localhost:5000/health', timeout=2)
-        status['nunba_server'] = 'running' if resp.status_code == 200 else f'status {resp.status_code}'
-    except Exception:
-        status['nunba_server'] = 'not reachable'
+    All probes flow through ``core.health_probe`` (single canonical
+    source).  See that module's docstring for the root-cause notes
+    on why we route through it instead of reading env vars directly.
+    """
+    from core.health_probe import (
+        probe_agent_daemon, probe_llm, probe_nunba_flask,
+    )
+    status = probe_agent_daemon()
+    status['nunba_server'] = probe_nunba_flask()
+    status['llm_server'] = probe_llm()
 
-    # Check LLM
-    try:
-        resp = pooled_get(f'http://localhost:{get_port("llm")}/health', timeout=2)
-        status['llm_server'] = 'running' if resp.status_code == 200 else f'status {resp.status_code}'
-    except Exception:
-        status['llm_server'] = 'not reachable'
-
-    # Goal counts
+    # Goal counts (DB query — kept inline; not a "probe" in the
+    # health-check sense, this is a count-by-status aggregation).
     try:
         from integrations.agent_engine.goal_manager import GoalManager
         db = _get_db()
@@ -312,37 +304,18 @@ def list_recipes() -> str:
 
 @mcp.tool()
 def system_health() -> str:
-    """Full system health check: Flask server, LLM, DB, memory graph."""
-    health = {}
+    """Full system health check: Flask server, LLM, DB, memory graph.
 
-    # Flask server
-    try:
-        resp = pooled_get('http://localhost:5000/health', timeout=2)
-        health['flask'] = {'status': 'up', 'code': resp.status_code}
-    except Exception:
-        health['flask'] = {'status': 'down'}
-
-    # LLM server
-    try:
-        resp = pooled_get(f'http://localhost:{get_port("llm")}/health', timeout=2)
-        health['llm'] = {'status': 'up', 'code': resp.status_code}
-        try:
-            models_resp = pooled_get(f'http://localhost:{get_port("llm")}/v1/models', timeout=2)
-            if models_resp.status_code == 200:
-                data = models_resp.json()
-                models = data.get('data', [])
-                health['llm']['models'] = [m.get('id', 'unknown') for m in models]
-        except Exception:
-            pass
-    except Exception:
-        health['llm'] = {'status': 'down'}
-
-    # LangChain agent (port 6778)
-    try:
-        resp = pooled_get('http://localhost:6778/health', timeout=2)
-        health['langchain'] = {'status': 'up' if resp.status_code == 200 else 'error'}
-    except Exception:
-        health['langchain'] = {'status': 'down'}
+    All non-DB probes flow through ``core.health_probe`` (single
+    canonical source).  See that module for why we no longer hit
+    ``localhost:{get_port('llm')}/health`` directly.
+    """
+    from core.health_probe import probe_nunba_flask, probe_llm, probe_langchain
+    health = {
+        'flask': probe_nunba_flask(),
+        'llm': probe_llm(),
+        'langchain': probe_langchain(),
+    }
 
     # DB
     try:

--- a/integrations/service_tools/gpu_worker.py
+++ b/integrations/service_tools/gpu_worker.py
@@ -866,6 +866,19 @@ def _resolve_python_exe() -> str:
     return sys.executable
 
 
+def _resolve_backend_venv_python(tool_name: Optional[str]) -> Optional[str]:
+    """Return the per-backend venv's python.exe if one exists.
+
+    Thin shim over ``core.venv_paths.venv_python_if_exists`` — kept as
+    a module-local name so the spawn-site call signature is stable.
+    The single source of truth lives in ``core.venv_paths`` and is
+    shared with ``tts.backend_venv`` so install + spawn paths can
+    never drift apart.
+    """
+    from core.venv_paths import venv_python_if_exists
+    return venv_python_if_exists(tool_name)
+
+
 # ═══════════════════════════════════════════════════════════════════
 # High-level helper: one-call tool wrapper
 # ═══════════════════════════════════════════════════════════════════
@@ -1242,12 +1255,23 @@ class ToolWorker:
                 cli_args = [self.tool_module]
                 if self.variant:
                     cli_args.append(self.variant)
+                # Resolve the spawn interpreter at start time, not at
+                # ToolWorker.__init__ time: the per-backend venv is
+                # typically created lazily on first install, AFTER the
+                # ToolWorker singleton has been constructed.  Order:
+                #   1. Explicit self.python_exe (test override / caller-set)
+                #   2. Per-backend venv at <data>/venvs/<tool_name>/  ← venv-installed deps
+                #   3. GPUWorker default = _resolve_python_exe() (python-embed)
+                spawn_python = (
+                    self.python_exe
+                    or _resolve_backend_venv_python(self.tool_name)
+                )
                 self._worker = GPUWorker(
                     name=self.tool_name,
                     module=self._DISPATCHER,
                     startup_timeout=self.startup_timeout,
                     request_timeout=self.request_timeout,
-                    python_exe=self.python_exe,
+                    python_exe=spawn_python,
                     args=cli_args,
                 )
                 self._worker.start()

--- a/integrations/service_tools/model_orchestrator.py
+++ b/integrations/service_tools/model_orchestrator.py
@@ -239,8 +239,46 @@ class ModelOrchestrator:
             return None
 
         if entry.loaded:
-            logger.info(f"Model already loaded: {model_id} ({entry.device})")
-            return entry
+            # Reconcile against the loader's live probe — entry.loaded
+            # is a CACHE that drifts when the underlying process dies
+            # externally (CUDA hang, OOM, manual kill, idle auto-stop
+            # outside our lifecycle).  Without this probe, the load()
+            # short-circuits with "Model already loaded" and the user
+            # sees a dead service ("Draft boot decision" loop on
+            # 2026-05-04 — task #80).  Loaders that override is_loaded()
+            # (LlamaLoader, TTSLoader, STTLoader, VLMLoader) return the
+            # actual liveness; the base class falls back to entry.loaded
+            # so loaders without an override preserve current behavior.
+            loader = self._loaders.get(entry.model_type)
+            try:
+                actually_loaded = (
+                    loader.is_loaded(entry) if loader else True
+                )
+            except Exception as _probe_err:
+                logger.warning(
+                    f"is_loaded probe failed for {model_id}: "
+                    f"{type(_probe_err).__name__}: {_probe_err} — "
+                    f"trusting cache flag"
+                )
+                actually_loaded = True
+            if actually_loaded:
+                logger.info(f"Model already loaded: {model_id} ({entry.device})")
+                return entry
+            # Cache lies — process is dead.  Reconcile state: release
+            # VRAM, clear the catalog flag, fall through to a fresh load.
+            logger.warning(
+                f"Stale cache for {model_id}: catalog says loaded but "
+                f"is_loaded() probe says dead — reconciling and "
+                f"respawning"
+            )
+            try:
+                self._release_vram(entry)
+            except Exception:
+                pass
+            try:
+                self._catalog.mark_unloaded(model_id)
+            except Exception:
+                pass
 
         cs = self._get_compute_state()
         fit = entry.matches_compute(

--- a/integrations/service_tools/pocket_tts_tool.py
+++ b/integrations/service_tools/pocket_tts_tool.py
@@ -170,6 +170,8 @@ def pocket_tts_synthesize(
         output_path = str(_get_output_dir() / f"tts_{h}.wav")
 
     # Try Pocket TTS (preferred)
+    import time as _time
+    _t0 = _time.monotonic()
     try:
         import numpy as np
         model = _load_model()
@@ -183,6 +185,16 @@ def pocket_tts_synthesize(
         scipy.io.wavfile.write(output_path, sr, audio_np)
 
         duration = len(audio_np) / sr
+        # Success log — required for #88: previously there was no
+        # runtime confirmation that pocket_tts was actually synthesizing
+        # (only failure paths logged).  Operators couldn't tell from
+        # langchain.log alone whether TTS was working or silently no-oping.
+        _elapsed_ms = int((_time.monotonic() - _t0) * 1000)
+        logger.info(
+            f"pocket_tts synthesized {len(text)}ch → {output_path} "
+            f"(sr={sr}Hz, dur={duration:.2f}s, voice={voice}, "
+            f"latency={_elapsed_ms}ms)"
+        )
         return json.dumps({
             "path": output_path,
             "duration": round(duration, 2),
@@ -197,6 +209,11 @@ def pocket_tts_synthesize(
 
     # Fallback: espeak-ng
     if _espeak_synthesize(text, output_path, voice="en"):
+        _elapsed_ms = int((_time.monotonic() - _t0) * 1000)
+        logger.info(
+            f"pocket_tts(espeak fallback) synthesized {len(text)}ch → "
+            f"{output_path} (latency={_elapsed_ms}ms)"
+        )
         return json.dumps({
             "path": output_path,
             "duration": 0,  # espeak doesn't report duration

--- a/integrations/social/_mesh_bandwidth_model.py
+++ b/integrations/social/_mesh_bandwidth_model.py
@@ -1,0 +1,178 @@
+"""Bandwidth model — mesh vs SFU per-peer cost crossover by call kind.
+
+Used to justify the per-kind defaults in api_calls._DEFAULT_KIND_THRESHOLDS.
+Real-world measurement (Task #276 live phase) is expected to validate
+or refine these constants — until then they are the *theoretical*
+crossover from first principles, not an arbitrary choice of 4.
+
+Topology cost model (per peer, sustained bitrate):
+
+    Mesh:  upload   = (N - 1) × bitrate_per_track    (encode once, send N-1 copies — *)
+           download = (N - 1) × bitrate_per_track    (one stream per other peer)
+
+    SFU:   upload   = 1 × bitrate_per_track          (one stream up to SFU)
+           download = (N - 1) × bitrate_per_track    (SFU forwards each peer's stream)
+
+(* `react-native-webrtc` and the LiveKit web SDK both emit a single
+   encoded copy per outgoing track and the OS-level networking layer
+   does the duplicate sends — so the *encode* cost is 1×, but the
+   *upload bandwidth* cost is (N-1)×.)
+
+For each call kind, the SFU starts winning on **per-peer upload** the
+moment (N - 1) > 1, i.e. at N ≥ 3.  But that's not the whole story:
+
+  - Mesh has a smaller signaling round-trip on the happy path
+    (no SFU media transit).
+  - Mesh is the only mode that actually preserves end-to-end media
+    encryption between users (SFU sees the media frames).
+  - Mesh keeps working when central / regional HARTOS is down.
+  - SFU adds operational complexity (binary lifecycle, port mgmt,
+    Redis for clusters) — only worth it when the bandwidth pain
+    actually shows up.
+
+So we use a different *practical* crossover per kind:
+
+  * voice (32 kbps Opus):
+      mesh upload at N=4 = 3 × 32 = 96 kbps — fine on every uplink.
+      mesh upload at N=5 = 4 × 32 = 128 kbps — still fine.
+      Default threshold = 4 (promote at N=5+).  Adoptable up to ~6
+      if measured.
+
+  * video (500 kbps default VP8):
+      mesh upload at N=3 = 2 × 500 = 1.0 Mbps — borderline on
+        residential ADSL up / shared 4G uplink.
+      mesh upload at N=4 = 3 × 500 = 1.5 Mbps — actively painful
+        for many residential connections.
+      Default threshold = 3 (promote at N=4+).
+
+  * screen_share, mixed:
+      Always SFU regardless of N.  Multi-track re-negotiation (camera +
+      screen + audio) on a mesh re-shuffles SDP for every peer; SFU
+      handles it once.  Threshold = 1 (promote at N=2+).
+
+These are *defaults*.  Operators can override per-kind via env vars
+(see api_calls._mesh_threshold).  Live measurement (Task #276) will
+validate.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, NamedTuple
+
+
+# Approximate sustained bitrates by media kind (kbps per outgoing track).
+KIND_BITRATE_KBPS = {
+    'voice': 32,         # Opus narrowband sweet spot
+    'video': 500,        # VP8 default, no simulcast
+    'video_simulcast': 1500,  # VP8 simulcast 3 layers (worst case)
+    'av1_video': 300,    # AV1 — 30-40% cheaper than VP8
+    'screen_share': 800, # screen 1080p25 typical
+}
+
+
+class CostPoint(NamedTuple):
+    n: int
+    mesh_up_kbps: float
+    mesh_down_kbps: float
+    sfu_up_kbps: float
+    sfu_down_kbps: float
+
+
+def crossover_table(kind: str = 'voice', max_n: int = 8) -> Dict[int, CostPoint]:
+    """Return per-peer bandwidth cost table for a given kind, N=2..max_n."""
+    bitrate = KIND_BITRATE_KBPS.get(kind, 500)
+    table: Dict[int, CostPoint] = {}
+    for n in range(2, max_n + 1):
+        peers = n - 1
+        table[n] = CostPoint(
+            n=n,
+            mesh_up_kbps=peers * bitrate,
+            mesh_down_kbps=peers * bitrate,
+            sfu_up_kbps=bitrate,
+            sfu_down_kbps=peers * bitrate,
+        )
+    return table
+
+
+def first_n_where_mesh_upload_exceeds(kind: str, ceiling_kbps: float) -> int:
+    """Return the smallest N where mesh upload per peer > ceiling_kbps.
+
+    Used to compute a 'promote to SFU' threshold given an uplink
+    budget.  E.g. if your residential ADSL uplink is 1000 kbps and the
+    call kind is video (500 kbps), this returns 3 (mesh upload at
+    N=3 = 2 × 500 = 1000 kbps which equals — at N=4 it exceeds).
+    """
+    bitrate = KIND_BITRATE_KBPS.get(kind, 500)
+    n = 2
+    while n <= 64:  # safety cap
+        if (n - 1) * bitrate > ceiling_kbps:
+            return n
+        n += 1
+    return 64
+
+
+# Bandwidth ceilings — conservative residential numbers used as
+# inputs to the model.
+RESIDENTIAL_UPLINK_KBPS = 1500   # 1.5 Mbps — ADSL / shared 4G floor
+MOBILE_4G_UPLINK_KBPS = 5000     # decent 4G — comfortable video uplink
+
+
+# ── Operational vs theoretical thresholds ─────────────────────────────
+#
+# The pure-bandwidth model alone produces *generous* thresholds:
+#   voice on 1500 kbps uplink: mesh ok through N=46  (32 kbps × 45)
+#   video on 1500 kbps uplink: mesh ok through N=4   (500 kbps × 3 = 1500)
+#
+# But mesh has costs the bandwidth model ignores:
+#   1. CPU encode is 1× regardless of N (the encoder emits one stream
+#      and the OS networking layer fans it out), BUT codec parameters
+#      become harder to negotiate as N grows — each additional peer's
+#      ICE/DTLS/SDP exchange happens on the call's hot path.
+#   2. Signaling round-trips: mesh has O(N²) signaling messages on
+#      join.  Past N=4 this starts adding visible "joining" latency.
+#   3. Subjective UX research (e.g., Hangouts / Meet older designs)
+#      consistently puts the "too noisy" boundary at 4-5 simultaneous
+#      audio sources without any active speaker detection.
+#
+# So the *operationally-chosen* defaults are tighter than the pure
+# bandwidth crossover.  Encoded in api_calls._DEFAULT_KIND_THRESHOLDS:
+#
+#   voice → 4   (mesh mode for ≤ 4 participants; SFU at 5+)
+#   video → 3   (mesh for ≤ 3; SFU at 4+ to leave headroom under 1500)
+#   screen_share → 1  (always SFU — multi-track re-negotiation is hard)
+#   mixed → 1         (always SFU — same reason)
+#
+# Live measurement (Task #276) is expected to validate these.  When it
+# does, OPERATIONAL_THRESHOLDS gets updated below + tests pinned.
+
+OPERATIONAL_THRESHOLDS = {
+    'voice': 4,
+    'video': 3,
+    'screen_share': 1,
+    'mixed': 1,
+}
+
+# Pure-bandwidth crossover (informational; not used as defaults).  These
+# are the largest N where mesh upload still fits within the residential
+# uplink ceiling.  Useful for operators on faster uplinks who want to
+# raise the threshold above the operational default.
+BANDWIDTH_ONLY_CEILING_AT_RESIDENTIAL = {
+    'voice': first_n_where_mesh_upload_exceeds(
+        'voice', RESIDENTIAL_UPLINK_KBPS) - 1,
+    'video': first_n_where_mesh_upload_exceeds(
+        'video', RESIDENTIAL_UPLINK_KBPS) - 1,
+    'screen_share': first_n_where_mesh_upload_exceeds(
+        'screen_share', RESIDENTIAL_UPLINK_KBPS) - 1,
+}
+
+
+__all__ = [
+    'KIND_BITRATE_KBPS',
+    'CostPoint',
+    'crossover_table',
+    'first_n_where_mesh_upload_exceeds',
+    'RESIDENTIAL_UPLINK_KBPS',
+    'MOBILE_4G_UPLINK_KBPS',
+    'OPERATIONAL_THRESHOLDS',
+    'BANDWIDTH_ONLY_CEILING_AT_RESIDENTIAL',
+]

--- a/integrations/social/api_calls.py
+++ b/integrations/social/api_calls.py
@@ -22,6 +22,7 @@ the requires_flag decorator pattern from api.py):
 from __future__ import annotations
 
 import logging
+import os
 
 from flask import Blueprint, request, g, jsonify
 
@@ -87,6 +88,51 @@ def get_call(call_id):
     return _ok(sess)
 
 
+# ── Mesh-first media-mode decision (PeerLink ↔ LiveKit complement) ──
+# By design HARTOS keeps voice/video on a P2P WebRTC mesh signaled
+# over PeerLink DISPATCH for small calls (cheap, low-latency, no SFU
+# round-trip).  LiveKit only takes over when:
+#   - participant count exceeds the mesh threshold (default 4 — N×N
+#     mesh fanout becomes inefficient past that), OR
+#   - any participant is an agent_bridge (the bridge needs a stable
+#     SFU rendezvous URL to publish TTS / subscribe STT), OR
+#   - the call kind is 'screen_share' or 'mixed' (multi-track → SFU
+#     simpler than re-negotiating mesh tracks).
+# Override via `LIVEKIT_MESH_THRESHOLD` env var (e.g. set to 0 to
+# always promote, or to 999 to disable promotion entirely for testing).
+
+
+def _mesh_threshold() -> int:
+    try:
+        return max(1, int(os.environ.get('LIVEKIT_MESH_THRESHOLD', '4')))
+    except (TypeError, ValueError):
+        return 4
+
+
+def _decide_media_mode(sess, participants, *, is_agent: bool) -> str:
+    """Return either 'p2p_mesh' or 'livekit'.
+
+    The endpoint uses this to choose between a LiveKit token (forwarded
+    to LiveKitService) or a {mode: 'p2p_mesh', signaling: 'peerlink'}
+    response telling the client to do its own WebRTC handshake over
+    the existing PeerLink DISPATCH channel.
+    """
+    if is_agent:
+        return 'livekit'
+    kind = (sess or {}).get('kind') or 'voice'
+    if kind in ('screen_share', 'mixed'):
+        return 'livekit'
+    # Count *active* participants — left_at IS NULL.
+    active = [p for p in (participants or []) if not p.get('left_at')]
+    # +1 for the caller about to join, if not already in the list.
+    caller_id = getattr(g.user, 'id', None)
+    if caller_id and not any(p.get('user_id') == caller_id for p in active):
+        active_count = len(active) + 1
+    else:
+        active_count = len(active)
+    return 'livekit' if active_count > _mesh_threshold() else 'p2p_mesh'
+
+
 @calls_bp.route('/calls/<call_id>/token', methods=['POST'])
 @require_auth
 @requires_flag('calls_v1')
@@ -98,11 +144,28 @@ def issue_token(call_id):
     if sess.get('ended_at'):
         return _err('call has ended', 410)
     data = _get_json()
+    is_agent = bool(data.get('is_agent', False))
+    participants = CallService.list_participants(g.db, call_id)
+
+    # Mesh-first: keep small calls on PeerLink-signaled WebRTC mesh.
+    # The client receives {mode: 'p2p_mesh'} and uses its existing
+    # PeerLink DISPATCH-channel signaling path — no LiveKit involved.
+    mode = _decide_media_mode(sess, participants, is_agent=is_agent)
+    if mode == 'p2p_mesh':
+        return _ok({
+            'mode': 'p2p_mesh',
+            'call_id': call_id,
+            'signaling': 'peerlink',
+            'participant_count': len(
+                [p for p in participants if not p.get('left_at')]),
+            'mesh_threshold': _mesh_threshold(),
+        })
+
     token = LiveKitService.issue_token(
         call_id, g.user.id,
         can_publish=bool(data.get('can_publish', True)),
         can_publish_screen=bool(data.get('can_publish_screen', False)),
-        is_agent=bool(data.get('is_agent', False)),
+        is_agent=is_agent,
         agent_bridge_node_id=data.get('agent_bridge_node_id'))
     return _ok(token)
 

--- a/integrations/social/api_calls.py
+++ b/integrations/social/api_calls.py
@@ -98,15 +98,46 @@ def get_call(call_id):
 #     SFU rendezvous URL to publish TTS / subscribe STT), OR
 #   - the call kind is 'screen_share' or 'mixed' (multi-track → SFU
 #     simpler than re-negotiating mesh tracks).
-# Override via `LIVEKIT_MESH_THRESHOLD` env var (e.g. set to 0 to
-# always promote, or to 999 to disable promotion entirely for testing).
+# Override via `LIVEKIT_MESH_THRESHOLD` (single int, applies to all
+# kinds) OR per-kind: `LIVEKIT_MESH_THRESHOLD_VOICE`,
+# `LIVEKIT_MESH_THRESHOLD_VIDEO`.  Set to 0 to always promote; 999 to
+# disable promotion entirely for testing.
+#
+# Default per-kind thresholds are derived from the bandwidth model in
+# integrations/social/_mesh_bandwidth_model.py — voice (audio-only,
+# 32 kbps Opus) stays cheap on mesh through N=4 (4× upload at N=4 is
+# 128 kbps — well within mobile uplinks).  Video (500 kbps default
+# VP8) crosses the per-peer upload pain point at N=3 (1 Mbps upload
+# for one person is asymmetric for residential ADSL / shared 4G), so
+# video calls promote to SFU one participant earlier.
+
+_DEFAULT_KIND_THRESHOLDS = {
+    'voice': 4,         # audio-only — cheap; mesh through 4
+    'video': 3,         # 500 kbps VP8 — SFU at N=3 saves uplink
+    'screen_share': 1,  # always SFU (handled by kind branch above)
+    'mixed': 1,         # always SFU (handled by kind branch above)
+}
 
 
-def _mesh_threshold() -> int:
+def _mesh_threshold(kind: str = 'voice') -> int:
+    """Resolve the mesh threshold for a given call kind.
+
+    Resolution order (highest priority first):
+      1. `LIVEKIT_MESH_THRESHOLD_<KIND>` env (per-kind override)
+      2. `LIVEKIT_MESH_THRESHOLD` env (uniform override across kinds)
+      3. _DEFAULT_KIND_THRESHOLDS[kind] (bandwidth-model default)
+      4. 4 (conservative fallback)
+    """
+    kind_env = f'LIVEKIT_MESH_THRESHOLD_{kind.upper()}'
+    val = os.environ.get(kind_env)
+    if val is None:
+        val = os.environ.get('LIVEKIT_MESH_THRESHOLD')
+    if val is None:
+        val = _DEFAULT_KIND_THRESHOLDS.get(kind, 4)
     try:
-        return max(1, int(os.environ.get('LIVEKIT_MESH_THRESHOLD', '4')))
+        return max(1, int(val))
     except (TypeError, ValueError):
-        return 4
+        return _DEFAULT_KIND_THRESHOLDS.get(kind, 4)
 
 
 def _decide_media_mode(sess, participants, *, is_agent: bool) -> str:
@@ -130,7 +161,7 @@ def _decide_media_mode(sess, participants, *, is_agent: bool) -> str:
         active_count = len(active) + 1
     else:
         active_count = len(active)
-    return 'livekit' if active_count > _mesh_threshold() else 'p2p_mesh'
+    return 'livekit' if active_count > _mesh_threshold(kind) else 'p2p_mesh'
 
 
 @calls_bp.route('/calls/<call_id>/token', methods=['POST'])

--- a/integrations/social/chat_messages.py
+++ b/integrations/social/chat_messages.py
@@ -341,3 +341,97 @@ def persist_and_publish_async(
             _run()
         except Exception:  # noqa: BLE001
             pass
+
+
+def persist_external_room_event(
+    user_id: str,
+    platform: str,
+    room_id: str,
+    sender_id: str,
+    text: str,
+    *,
+    kind: str = 'external_room_msg',
+    timestamp: float | None = None,
+    role: str | None = None,
+    msg_id: str | None = None,
+    lang: str | None = None,
+    extra: dict | None = None,
+) -> None:
+    """Canonical SINGLE-WRITER for cross-channel external-room events
+    (UNIF-G3).  Channel adapters and the agent_voice_bridge worker MUST
+    call this when an inbound message arrives from an external room
+    (Discord channel msg, Slack channel msg, voice transcript segment,
+    Matrix room post, Telegram super-group msg, WhatsApp group msg, etc.).
+
+    Why a thin wrapper around ``persist_and_publish_async`` rather than
+    each adapter calling that directly: this is the ONE place that
+    encodes the canonical (platform, room_id, sender, ts, kind) shape
+    into the existing ``ConversationEntry`` columns
+    (``channel_type``, ``request_id``, ``device_id``, ``attachments``).
+    A new adapter wires up cross-channel ingest by importing this one
+    helper — no per-adapter copy of the field-mapping logic.
+
+    Field mapping into the canonical ``ConversationEntry``:
+      - ``channel_type`` ← ``f"{platform}:{room_id}"`` (composite — both
+        platform AND room are addressable in the recall surface)
+      - ``request_id``   ← ``room_id`` (groups all events from the same
+        room for thread-style recall)
+      - ``device_id``    ← ``f"adapter:{platform}"`` (tells the chat-sync
+        consumer this came from an external adapter, not a local device)
+      - ``role``         ← caller-specified or auto-derived from sender
+                            (matches the agent's own user_id → role='assistant',
+                            else role='user')
+      - ``content``      ← the raw text of the external event
+      - ``attachments``  ← ``[{kind, platform, room_id, author, t}]``
+                            for full provenance recall
+
+    Voice transcript segments use ``kind='transcript_segment'`` (with
+    ``extra={'t0', 't1', 'speaker'}``) — the agent_voice_bridge worker
+    pipes whisper_tool's streaming WebSocket output through here.
+
+    Per ``feedback_test_what_we_ship.md`` — this helper has unit tests
+    in ``tests/unit/test_chat_messages_external.py``.
+
+    Best-effort: never raises out of the hot path.
+    """
+    if not user_id or not platform or not room_id or not text:
+        logger.debug(
+            "chat_messages.persist_external_room_event: skipping "
+            "(missing required field): platform=%r room=%r sender=%r",
+            platform, room_id, sender_id)
+        return
+
+    # Auto-derive role: anything from "the agent itself" is 'assistant';
+    # everything else is 'user'.  Caller can override.
+    if role is None:
+        # Heuristic: sender id of the form "agent:..." or matching the
+        # owner's agent identity → assistant.  Default to 'user'.
+        role = 'assistant' if str(sender_id or '').startswith('agent:') else 'user'
+
+    attachment = {
+        'kind': kind,
+        'platform': platform,
+        'room_id': room_id,
+        'author': sender_id,
+    }
+    if timestamp is not None:
+        attachment['t'] = timestamp
+    if extra:
+        # Merge caller-supplied per-kind metadata (e.g. transcript
+        # segment t0/t1/speaker) — keep adapter-specific keys out of
+        # the canonical attachment shape.
+        for k, v in extra.items():
+            if k not in attachment:
+                attachment[k] = v
+
+    persist_and_publish_async(
+        user_id,
+        role,
+        text,
+        msg_id=msg_id,
+        request_id=room_id,
+        device_id=f'adapter:{platform}',
+        lang=lang,
+        attachments=[attachment],
+        channel_type=f'{platform}:{room_id}',
+    )

--- a/integrations/social/distribution_service.py
+++ b/integrations/social/distribution_service.py
@@ -24,6 +24,31 @@ def _generate_code(length: int = 8) -> str:
     return ''.join(secrets.choice(chars) for _ in range(length))
 
 
+def invite_share_url(code: str, base_url: Optional[str] = None) -> str:
+    """Build the canonical shareable invite URL for a referral code.
+
+    Single source of truth — replaces the hardcoded
+    ``f"https://hevolve.ai/join?ref={ref_code}"`` previously inlined at
+    ``marketing_tools.py:create_referral_campaign`` and any new G1
+    invite-friend tool.  Reads ``HEVOLVE_INVITE_BASE_URL`` env var first
+    (so dev / staging / on-prem deployments can override) and defaults
+    to the canonical ``https://hevolve.ai/join`` per the marketing
+    canon.
+
+    Returns a URL of the form ``<base>?ref=<CODE>``.  The path is
+    intentionally identical to the legacy hardcoded one so existing
+    inbound traffic that lands on ``hevolve.ai/join?ref=…`` continues
+    to work unchanged.
+    """
+    import os
+    if not code:
+        raise ValueError("invite_share_url requires a non-empty code")
+    base = base_url or os.environ.get(
+        'HEVOLVE_INVITE_BASE_URL', 'https://hevolve.ai/join')
+    sep = '&' if '?' in base else '?'
+    return f"{base}{sep}ref={code}"
+
+
 class DistributionService:
 
     # ─── Referrals ───

--- a/integrations/social/livekit_service.py
+++ b/integrations/social/livekit_service.py
@@ -56,15 +56,48 @@ except Exception:
     _HAS_LIVEKIT_SDK = False
 
 
-def _has_livekit_config() -> bool:
-    """True iff the central LiveKit env vars are set.  Flat / regional
-    / Nunba bundled deploys leave these unset, so this returns False
-    and clients route to P2P mesh.
+def _resolved_config():
+    """Return (url, api_key, api_secret) — env-vars override; else fall
+    back to the supervisor's auto-generated dev keys + localhost URL.
+
+    Flat/regional installs that haven't been provisioned with central-
+    issued keys still get a working signer because livekit_supervisor
+    auto-generates a dev key/secret pair on first start.  Central
+    deploys (which don't host an SFU) leave LIVEKIT_DISABLE=1; that
+    short-circuits supervisor_should_run() so no dev keys exist and
+    we fall back to the {mode: 'p2p_mesh'} response.
     """
-    return bool(
-        os.environ.get('LIVEKIT_URL')
-        and os.environ.get('LIVEKIT_API_KEY')
-        and os.environ.get('LIVEKIT_API_SECRET'))
+    env_url = os.environ.get('LIVEKIT_URL')
+    env_key = os.environ.get('LIVEKIT_API_KEY')
+    env_secret = os.environ.get('LIVEKIT_API_SECRET')
+    if env_url and env_key and env_secret:
+        return env_url, env_key, env_secret
+
+    # Lazy import to avoid a circular dep during module init.
+    try:
+        from .livekit_supervisor import (
+            ensure_dev_keys,
+            get_livekit_url,
+            supervisor_should_run,
+        )
+    except Exception:  # pragma: no cover — defensive
+        return None, None, None
+
+    if not supervisor_should_run():
+        return None, None, None
+
+    keys = ensure_dev_keys()
+    url = env_url or get_livekit_url()
+    return url, keys.get('api_key'), keys.get('api_secret')
+
+
+def _has_livekit_config() -> bool:
+    """True iff we have a complete (url, api_key, api_secret) triple
+    — either from operator-set env vars OR from the supervisor's auto-
+    generated dev keys when running in flat/regional mode.
+    """
+    url, key, secret = _resolved_config()
+    return bool(url and key and secret)
 
 
 class LiveKitService:
@@ -90,16 +123,14 @@ class LiveKitService:
         When mode='p2p_mesh', the result is just {mode, call_id} and
         the client does its own WebRTC handshake via PeerLink.
         """
-        if not _has_livekit_config():
+        url, api_key, api_secret = _resolved_config()
+        if not (url and api_key and api_secret):
             return {
                 'mode': 'p2p_mesh',
                 'call_id': call_id,
-                'reason': 'no LIVEKIT_URL configured (flat/regional/bundled deploy)',
+                'reason': 'no LIVEKIT config; central/embedded deploy or '
+                          'LIVEKIT_DISABLE=1 set',
             }
-
-        url = os.environ['LIVEKIT_URL']
-        api_key = os.environ['LIVEKIT_API_KEY']
-        api_secret = os.environ['LIVEKIT_API_SECRET']
 
         metadata = {
             'agent_kind': 'agent' if is_agent else 'human',
@@ -163,7 +194,8 @@ class LiveKitService:
     @staticmethod
     def end_room(call_id: str) -> Dict[str, Any]:
         """Tear down a LiveKit room.  No-op when no LiveKit configured."""
-        if not _has_livekit_config():
+        url, _key, _secret = _resolved_config()
+        if not url:
             return {'mode': 'p2p_mesh', 'ended': True}
         # SDK delete_room is async (asyncio coroutine) — for now we
         # just signal end-of-call; the actual API call lands in a

--- a/integrations/social/livekit_supervisor.py
+++ b/integrations/social/livekit_supervisor.py
@@ -1,0 +1,638 @@
+"""
+LiveKit supervisor — self-hosted SFU lifecycle, baked into HARTOS.
+
+PURPOSE
+-------
+HARTOS is mostly P2P (PeerLink + WebRTC mesh signaling).  LiveKit is the
+FALLBACK SFU that kicks in when:
+  - Call has > 4 participants (mesh inefficient)
+  - One participant is an AgentVoiceBridge (needs a stable rendezvous URL)
+
+ARCHITECTURE INTENT (per user clarification 2026-05-07)
+-------------------------------------------------------
+* **regional** — multi-tenant SFU host.  Runs `livekit-server` locally,
+  signing JWTs with locally-generated dev keys.  This module spawns the
+  binary as a managed subprocess.
+* **flat** (single device) — same as regional but typically only one
+  tenant.  Supervisor still runs so >4-participant calls work.
+* **central** — sync / federation / backup-restore only.  Does NOT run
+  an SFU.  This module is a no-op when LIVEKIT_DISABLE=1 or
+  HEVOLVE_DEPLOY_MODE=central.
+* **embedded** — bundled mobile node.  No SFU; same as central.
+
+ZERO-CONFIG GOAL
+----------------
+`pip install -e .` plus first start of HARTOS should produce a working
+SFU on regional/flat with no manual setup.  This module:
+  1. Generates AES-256-grade API key + secret on first start, persists
+     them in ~/.hevolve/livekit/dev_keys.json (mode 0600).
+  2. Lazy-downloads the official `livekit-server` Go binary from the
+     LiveKit GitHub release that matches the pinned version, verifies
+     the SHA-256 against an embedded checksum, and installs to
+     ~/.hevolve/livekit/livekit-server (or .exe on Windows).
+  3. Generates a config file (~/.hevolve/livekit/livekit.yaml) wiring
+     the dev keys, port (default 7880), TURN/TCP fallback, and Redis
+     when HEVOLVE_REDIS_URL is set (multi-node regional clusters).
+  4. Spawns the binary as a daemon-thread-managed subprocess; restarts
+     on crash with exponential backoff capped at 60s.
+  5. Exposes runtime status via .info() so /health endpoints can report.
+
+The token issuer (livekit_service.py) reads the same dev keys file, so
+both sides share a single source of truth — no copy-paste configuration.
+
+This module is INTENTIONALLY decoupled from the binary fetch URL: the
+default GitHub release URL can be overridden via LIVEKIT_BINARY_URL for
+air-gapped installs, ISO builds (which pre-stage the binary), or
+proxied environments.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import platform
+import secrets
+import shutil
+import socket
+import stat
+import subprocess
+import threading
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger('hevolve_social')
+
+
+# ── Pinned binary version ──────────────────────────────────────────────
+# Bump together: VERSION, SHA-256 per platform.  When upgrading, run:
+#   curl -sL https://github.com/livekit/livekit/releases/download/v$VERSION/livekit_${VERSION}_linux_amd64.tar.gz | sha256sum
+# and update the table below.
+LIVEKIT_VERSION = '1.7.2'
+
+# SHA-256 of the official tarballs from
+# https://github.com/livekit/livekit/releases/tag/v1.7.2
+# Empty string → checksum verification skipped (when not yet pinned).
+# CI / hardening can pin these later; for now we accept the binary as-is
+# but log the actual checksum so a follow-up PR can fill the table.
+_LIVEKIT_SHA256 = {
+    'linux-amd64':  '',
+    'linux-arm64':  '',
+    'darwin-amd64': '',
+    'darwin-arm64': '',
+    'windows-amd64': '',
+}
+
+
+# ── Filesystem layout ─────────────────────────────────────────────────
+def _hevolve_home() -> Path:
+    """`~/.hevolve` — shared HARTOS data dir.  Override via HEVOLVE_HOME."""
+    base = os.environ.get('HEVOLVE_HOME')
+    if base:
+        return Path(base).expanduser()
+    return Path.home() / '.hevolve'
+
+
+def _livekit_home() -> Path:
+    return _hevolve_home() / 'livekit'
+
+
+DEV_KEYS_FILE = 'dev_keys.json'   # {api_key, api_secret, generated_at}
+CONFIG_FILE   = 'livekit.yaml'
+BINARY_NAME   = 'livekit-server.exe' if os.name == 'nt' else 'livekit-server'
+
+
+# ── Deploy-mode detection ─────────────────────────────────────────────
+def _deploy_mode() -> str:
+    """Return one of `flat | regional | central | embedded`.
+
+    Resolution order:
+      1. `HEVOLVE_DEPLOY_MODE` env var.
+      2. `LIVEKIT_DISABLE=1` → forces 'central' (skip everything).
+      3. Default 'flat' (laptop dev / single-device install).
+    """
+    if os.environ.get('LIVEKIT_DISABLE') == '1':
+        return 'central'
+    return os.environ.get('HEVOLVE_DEPLOY_MODE', 'flat').lower().strip()
+
+
+def supervisor_should_run() -> bool:
+    """True iff this deploy mode hosts the SFU itself.
+
+    Central + embedded skip everything (sync/federation/backup-only).
+    Regional + flat run the supervised binary.
+
+    Override: set `LIVEKIT_AUTOSTART=0` to force-disable, or
+    `LIVEKIT_AUTOSTART=1` to force-enable regardless of deploy mode.
+    """
+    forced = os.environ.get('LIVEKIT_AUTOSTART')
+    if forced == '0':
+        return False
+    if forced == '1':
+        return True
+    return _deploy_mode() in ('flat', 'regional')
+
+
+# ── Dev-key bootstrap (shared with livekit_service token issuer) ──────
+def ensure_dev_keys() -> Dict[str, str]:
+    """Return {api_key, api_secret} — generates + persists on first call.
+
+    Idempotent: same keys returned across restarts.  Safe to call from
+    multiple processes (atomic write via temp + rename).  Permissions:
+    0700 dir, 0600 file (POSIX).  On Windows we rely on user-profile
+    ACLs (CreateDirectoryW restricts to the current user by default).
+
+    Env override: if LIVEKIT_API_KEY + LIVEKIT_API_SECRET are both set,
+    those win — we don't write the dev_keys.json.  This is the path
+    operators use when deploying with managed LiveKit Cloud or a
+    central-issued key/secret pair.
+    """
+    env_key = os.environ.get('LIVEKIT_API_KEY')
+    env_secret = os.environ.get('LIVEKIT_API_SECRET')
+    if env_key and env_secret:
+        return {'api_key': env_key, 'api_secret': env_secret}
+
+    home = _livekit_home()
+    home.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(home, 0o700)
+    except OSError:
+        pass  # Windows / restricted FS — best effort.
+
+    keys_path = home / DEV_KEYS_FILE
+    if keys_path.exists():
+        try:
+            with keys_path.open('r', encoding='utf-8') as fp:
+                data = json.load(fp)
+            if data.get('api_key') and data.get('api_secret'):
+                return data
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning(
+                "livekit_supervisor: could not read %s (%s); regenerating",
+                keys_path, e)
+
+    # First boot — generate.  LiveKit accepts an arbitrary string for
+    # api_key (commonly prefixed `API`); we use a 16-byte random hex for
+    # easy diffing in logs.  Secret is 32 bytes (256-bit HMAC key).
+    new_keys = {
+        'api_key': 'API' + secrets.token_hex(8),
+        'api_secret': secrets.token_urlsafe(32),
+        'generated_at': int(time.time()),
+        'generated_by': 'livekit_supervisor.ensure_dev_keys',
+    }
+    tmp_path = keys_path.with_suffix('.tmp')
+    with tmp_path.open('w', encoding='utf-8') as fp:
+        json.dump(new_keys, fp, indent=2)
+    try:
+        os.chmod(tmp_path, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp_path, keys_path)
+    logger.info(
+        "livekit_supervisor: generated dev keys (api_key=%s) at %s",
+        new_keys['api_key'], keys_path)
+    return new_keys
+
+
+def get_livekit_url() -> str:
+    """Resolve the URL clients should connect to.
+
+    Order:
+      1. `LIVEKIT_URL` env var (managed cloud or operator override).
+      2. `ws://localhost:<LIVEKIT_PORT>` (default 7880) for self-hosted.
+    """
+    url = os.environ.get('LIVEKIT_URL')
+    if url:
+        return url
+    port = os.environ.get('LIVEKIT_PORT', '7880')
+    return f'ws://localhost:{port}'
+
+
+# ── Binary download + verify ──────────────────────────────────────────
+def _platform_tag() -> str:
+    sys_name = platform.system().lower()  # 'linux'/'darwin'/'windows'
+    machine = platform.machine().lower()
+    if machine in ('x86_64', 'amd64'):
+        arch = 'amd64'
+    elif machine in ('aarch64', 'arm64'):
+        arch = 'arm64'
+    else:
+        arch = machine
+    if sys_name == 'darwin':
+        return f'darwin-{arch}'
+    if sys_name == 'windows':
+        return f'windows-{arch}'
+    return f'linux-{arch}'
+
+
+def _binary_url() -> str:
+    """Resolve the binary archive URL.  `LIVEKIT_BINARY_URL` lets ISO /
+    air-gapped builds point at a local mirror or cached file://."""
+    override = os.environ.get('LIVEKIT_BINARY_URL')
+    if override:
+        return override
+    tag = _platform_tag()
+    ext = 'zip' if tag.startswith('windows-') else 'tar.gz'
+    return (
+        f'https://github.com/livekit/livekit/releases/download/'
+        f'v{LIVEKIT_VERSION}/livekit_{LIVEKIT_VERSION}_{tag}.{ext}'
+    )
+
+
+def _verify_sha256(path: Path, tag: str) -> None:
+    expected = _LIVEKIT_SHA256.get(tag, '')
+    h = hashlib.sha256()
+    with path.open('rb') as fp:
+        for chunk in iter(lambda: fp.read(1 << 16), b''):
+            h.update(chunk)
+    actual = h.hexdigest()
+    if not expected:
+        logger.info(
+            "livekit_supervisor: download checksum (%s) = %s — pinning "
+            "deferred; set _LIVEKIT_SHA256[%r] in livekit_supervisor.py "
+            "to lock this version", tag, actual, tag)
+        return
+    if expected.lower() != actual.lower():
+        raise RuntimeError(
+            f'LiveKit binary checksum mismatch for {tag}: '
+            f'expected {expected}, got {actual}')
+
+
+def _find_prestaged_binary() -> Optional[Path]:
+    """Look for an already-installed livekit-server in standard
+    locations.  Used by Docker (Dockerfile installs to /usr/local/bin)
+    and ISO builds (apt/manual install) so the supervisor doesn't
+    re-download a binary already present.
+
+    Order: explicit `LIVEKIT_BINARY_PATH` env > `~/.hevolve/livekit/`
+    > shutil.which() (PATH lookup).
+    """
+    explicit = os.environ.get('LIVEKIT_BINARY_PATH')
+    if explicit:
+        p = Path(explicit).expanduser()
+        if p.exists():
+            return p
+
+    home_path = _livekit_home() / BINARY_NAME
+    if home_path.exists():
+        return home_path
+
+    on_path = shutil.which('livekit-server')
+    if on_path:
+        return Path(on_path)
+    return None
+
+
+def ensure_binary() -> Optional[Path]:
+    """Download + extract the livekit-server binary if missing.
+
+    Returns the absolute path to the binary, or None if the download
+    couldn't be completed (logged; supervisor will degrade to
+    p2p_mesh-only mode).
+
+    Safe to call repeatedly: existence check short-circuits.  Will
+    prefer a pre-staged binary (Dockerfile / ISO / apt install) over
+    a fresh download.
+    """
+    pre = _find_prestaged_binary()
+    if pre:
+        return pre
+
+    home = _livekit_home()
+    binary_path = home / BINARY_NAME
+    if binary_path.exists():
+        return binary_path
+
+    home.mkdir(parents=True, exist_ok=True)
+    tag = _platform_tag()
+    url = _binary_url()
+
+    logger.info(
+        "livekit_supervisor: fetching livekit-server v%s for %s from %s",
+        LIVEKIT_VERSION, tag, url)
+
+    archive_ext = 'zip' if url.endswith('.zip') else 'tar.gz'
+    archive_path = home / f'livekit-server-{LIVEKIT_VERSION}.{archive_ext}'
+
+    try:
+        # Use urllib only — no extra deps.  Set a UA so GitHub's CDN
+        # doesn't 403 on default Python signature.
+        req = urllib.request.Request(
+            url, headers={'User-Agent': 'HARTOS-livekit-supervisor/1.0'})
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            with archive_path.open('wb') as fp:
+                shutil.copyfileobj(resp, fp)
+    except Exception as e:  # network / 404 / permissions
+        logger.warning(
+            "livekit_supervisor: download failed (%s); SFU will not "
+            "start.  Calls fall back to P2P mesh.  To install manually: "
+            "download %s and extract to %s",
+            e, url, home)
+        return None
+
+    _verify_sha256(archive_path, tag)
+
+    # Extract binary out of the archive.  LiveKit ships either a .tar.gz
+    # (Linux/macOS) or .zip (Windows) containing a single
+    # `livekit-server` (or `.exe`) at the root.
+    try:
+        if archive_ext == 'zip':
+            import zipfile
+            with zipfile.ZipFile(archive_path) as z:
+                for name in z.namelist():
+                    base = os.path.basename(name)
+                    if base in ('livekit-server', 'livekit-server.exe'):
+                        with z.open(name) as src, binary_path.open('wb') as dst:
+                            shutil.copyfileobj(src, dst)
+                        break
+        else:
+            import tarfile
+            with tarfile.open(archive_path, 'r:gz') as t:
+                for member in t.getmembers():
+                    base = os.path.basename(member.name)
+                    if base == 'livekit-server':
+                        f = t.extractfile(member)
+                        if f is None:
+                            continue
+                        with binary_path.open('wb') as dst:
+                            shutil.copyfileobj(f, dst)
+                        break
+    finally:
+        try:
+            archive_path.unlink()
+        except OSError:
+            pass
+
+    if not binary_path.exists():
+        logger.warning(
+            "livekit_supervisor: archive extraction did not produce a "
+            "livekit-server binary at %s; SFU disabled", binary_path)
+        return None
+
+    # 0755 so it's runnable by the current user.
+    try:
+        st = binary_path.stat()
+        os.chmod(binary_path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP)
+    except OSError:
+        pass
+    logger.info(
+        "livekit_supervisor: livekit-server v%s installed at %s",
+        LIVEKIT_VERSION, binary_path)
+    return binary_path
+
+
+# ── Config generation ─────────────────────────────────────────────────
+def _generate_config(keys: Dict[str, str]) -> Path:
+    """Emit `livekit.yaml` with the dev keys + standard ports.
+
+    Uses the official LiveKit config schema.  Operators can override
+    fields by editing the file or setting env vars HARTOS reads on
+    next start.
+    """
+    home = _livekit_home()
+    home.mkdir(parents=True, exist_ok=True)
+    cfg_path = home / CONFIG_FILE
+
+    port = int(os.environ.get('LIVEKIT_PORT', '7880'))
+    rtc_tcp_port = int(os.environ.get('LIVEKIT_RTC_TCP_PORT', '7881'))
+    rtc_udp_min = int(os.environ.get('LIVEKIT_RTC_UDP_MIN', '50000'))
+    rtc_udp_max = int(os.environ.get('LIVEKIT_RTC_UDP_MAX', '60000'))
+    redis_url = os.environ.get('HEVOLVE_REDIS_URL') or os.environ.get(
+        'LIVEKIT_REDIS_URL')
+
+    yaml_lines = [
+        '# Auto-generated by HARTOS livekit_supervisor.  Edit if you',
+        '# need to override; HARTOS will not overwrite an existing',
+        '# config — delete the file to regenerate from current env.',
+        f'port: {port}',
+        'bind_addresses:',
+        "  - ''",  # listen on all interfaces
+        'rtc:',
+        f'  tcp_port: {rtc_tcp_port}',
+        f'  port_range_start: {rtc_udp_min}',
+        f'  port_range_end: {rtc_udp_max}',
+        '  use_external_ip: true',
+        'keys:',
+        f'  {keys["api_key"]}: {keys["api_secret"]}',
+        'logging:',
+        '  level: info',
+        '  json: false',
+    ]
+    if redis_url:
+        yaml_lines += [
+            'redis:',
+            f'  address: {redis_url}',
+        ]
+
+    if not cfg_path.exists():
+        with cfg_path.open('w', encoding='utf-8') as fp:
+            fp.write('\n'.join(yaml_lines) + '\n')
+        try:
+            os.chmod(cfg_path, 0o600)
+        except OSError:
+            pass
+        logger.info(
+            "livekit_supervisor: wrote default config at %s", cfg_path)
+    else:
+        logger.info(
+            "livekit_supervisor: keeping existing config at %s "
+            "(delete to regenerate)", cfg_path)
+    return cfg_path
+
+
+def _port_in_use(port: int) -> bool:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.5)
+            return s.connect_ex(('127.0.0.1', port)) == 0
+    except OSError:
+        return False
+
+
+# ── Supervisor lifecycle ──────────────────────────────────────────────
+class _Supervisor:
+    """Single instance per HARTOS process.  Started by start_supervisor()
+    and lives for the lifetime of the process.  Daemon thread → exits
+    cleanly when the parent dies.
+    """
+
+    def __init__(self) -> None:
+        self.proc: Optional[subprocess.Popen] = None
+        self.binary: Optional[Path] = None
+        self.config: Optional[Path] = None
+        self.thread: Optional[threading.Thread] = None
+        self.stop_event = threading.Event()
+        self.last_error: Optional[str] = None
+        self.last_started: Optional[float] = None
+        self.restart_count = 0
+        self.url: str = get_livekit_url()
+        self.lock = threading.Lock()
+
+    def start(self) -> Dict[str, Any]:
+        """Provision keys + binary + config; spawn the supervisor thread.
+
+        Returns an info dict with status the caller can log or surface
+        on a health endpoint.
+        """
+        if self.thread is not None and self.thread.is_alive():
+            return self.info()
+
+        keys = ensure_dev_keys()
+        self.binary = ensure_binary()
+        self.config = _generate_config(keys)
+
+        if self.binary is None:
+            self.last_error = (
+                'binary unavailable — calls fall back to P2P mesh only')
+            logger.warning(
+                "livekit_supervisor: %s", self.last_error)
+            return self.info()
+
+        port = int(os.environ.get('LIVEKIT_PORT', '7880'))
+        if _port_in_use(port):
+            self.last_error = (
+                f'port {port} already in use; assuming an operator-'
+                f'managed livekit-server is running and skipping spawn')
+            logger.info("livekit_supervisor: %s", self.last_error)
+            return self.info()
+
+        self.thread = threading.Thread(
+            target=self._run, daemon=True, name='livekit-supervisor')
+        self.thread.start()
+        return self.info()
+
+    def stop(self) -> None:
+        self.stop_event.set()
+        with self.lock:
+            if self.proc and self.proc.poll() is None:
+                try:
+                    self.proc.terminate()
+                    try:
+                        self.proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        self.proc.kill()
+                except OSError:
+                    pass
+
+    def _run(self) -> None:
+        backoff = 1.0
+        while not self.stop_event.is_set():
+            try:
+                cmd = [str(self.binary), '--config', str(self.config)]
+                logger.info("livekit_supervisor: spawning %s", ' '.join(cmd))
+                with self.lock:
+                    self.proc = subprocess.Popen(
+                        cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        cwd=str(_livekit_home()),
+                    )
+                    self.last_started = time.time()
+                # Stream output to logger so operators see what's happening
+                # without needing to tail the binary's own log file.
+                if self.proc.stdout is not None:
+                    for raw in self.proc.stdout:
+                        if self.stop_event.is_set():
+                            break
+                        line = raw.decode('utf-8', errors='replace').rstrip()
+                        if line:
+                            logger.info('livekit-server: %s', line)
+                rc = self.proc.wait()
+                if self.stop_event.is_set():
+                    return
+                self.last_error = f'livekit-server exited rc={rc}'
+                logger.warning("livekit_supervisor: %s", self.last_error)
+            except Exception as e:
+                self.last_error = f'spawn failed: {e}'
+                logger.error("livekit_supervisor: %s", self.last_error,
+                             exc_info=True)
+
+            # Exponential backoff capped at 60s.
+            self.restart_count += 1
+            wait = min(backoff, 60.0)
+            backoff = min(backoff * 2.0, 60.0)
+            if self.stop_event.wait(wait):
+                return
+
+    def info(self) -> Dict[str, Any]:
+        running = (
+            self.proc is not None
+            and self.proc.poll() is None
+            and self.thread is not None
+            and self.thread.is_alive()
+        )
+        return {
+            'mode': _deploy_mode(),
+            'should_run': supervisor_should_run(),
+            'binary_path': str(self.binary) if self.binary else None,
+            'config_path': str(self.config) if self.config else None,
+            'url': self.url,
+            'running': running,
+            'restart_count': self.restart_count,
+            'last_started': self.last_started,
+            'last_error': self.last_error,
+        }
+
+
+_INSTANCE: Optional[_Supervisor] = None
+_INSTANCE_LOCK = threading.Lock()
+
+
+def start_supervisor() -> Dict[str, Any]:
+    """Idempotent entrypoint — call once during HARTOS bootstrap.
+
+    No-op when the deploy mode shouldn't host an SFU (central /
+    embedded), preserving the architectural intent that central
+    instances do sync/federation/backup-restore only.
+    """
+    global _INSTANCE
+    if not supervisor_should_run():
+        return {
+            'mode': _deploy_mode(),
+            'should_run': False,
+            'reason':
+                'deploy mode does not host an SFU; calls use P2P mesh '
+                'and any operator-managed external LiveKit URL',
+        }
+
+    with _INSTANCE_LOCK:
+        if _INSTANCE is None:
+            _INSTANCE = _Supervisor()
+        return _INSTANCE.start()
+
+
+def stop_supervisor() -> None:
+    """Process-shutdown hook.  Safe to call when supervisor never ran."""
+    global _INSTANCE
+    with _INSTANCE_LOCK:
+        if _INSTANCE is not None:
+            _INSTANCE.stop()
+            _INSTANCE = None
+
+
+def supervisor_info() -> Dict[str, Any]:
+    """Read-only state — useful for /health, debug pages, tests."""
+    with _INSTANCE_LOCK:
+        if _INSTANCE is None:
+            return {
+                'mode': _deploy_mode(),
+                'should_run': supervisor_should_run(),
+                'running': False,
+                'reason': 'not yet started',
+            }
+        return _INSTANCE.info()
+
+
+__all__ = [
+    'LIVEKIT_VERSION',
+    'ensure_dev_keys',
+    'get_livekit_url',
+    'ensure_binary',
+    'supervisor_should_run',
+    'start_supervisor',
+    'stop_supervisor',
+    'supervisor_info',
+]

--- a/integrations/social/livekit_supervisor.py
+++ b/integrations/social/livekit_supervisor.py
@@ -68,22 +68,27 @@ logger = logging.getLogger('hevolve_social')
 
 
 # ── Pinned binary version ──────────────────────────────────────────────
-# Bump together: VERSION, SHA-256 per platform.  When upgrading, run:
-#   curl -sL https://github.com/livekit/livekit/releases/download/v$VERSION/livekit_${VERSION}_linux_amd64.tar.gz | sha256sum
-# and update the table below.
+# Bump together: VERSION + SHA-256 table.  When upgrading:
+#   curl -sL https://github.com/livekit/livekit/releases/download/v$VERSION/checksums.txt
+# and copy the hashes for the platforms we ship.
 LIVEKIT_VERSION = '1.7.2'
 
-# SHA-256 of the official tarballs from
-# https://github.com/livekit/livekit/releases/tag/v1.7.2
-# Empty string → checksum verification skipped (when not yet pinned).
-# CI / hardening can pin these later; for now we accept the binary as-is
-# but log the actual checksum so a follow-up PR can fill the table.
+# SHA-256 of the official release artifacts from
+# https://github.com/livekit/livekit/releases/download/v1.7.2/checksums.txt
+# These are pinned for supply-chain integrity — a download whose hash
+# doesn't match is rejected by ensure_binary().
+#
+# Note: LiveKit does NOT ship darwin (macOS) builds in this release
+# series.  Operators on Apple Silicon must either install via Homebrew
+# (`brew install livekit-server`) and let the supervisor's PATH lookup
+# find it, or set LIVEKIT_BINARY_PATH explicitly.
 _LIVEKIT_SHA256 = {
-    'linux-amd64':  '',
-    'linux-arm64':  '',
-    'darwin-amd64': '',
-    'darwin-arm64': '',
-    'windows-amd64': '',
+    'linux-amd64':   '7669b1a112449e71ff80cb82460dae7e526e92b3d81e15c70f66a030fac62f4a',
+    'linux-arm64':   '482ced7026cbf4c661ab262d04e2d1ba4a723a478bd87028cd27a8a4bcf38035',
+    'linux-armv7':   '68a48cf10b2641aaca449ec61018922a2e3294b2682ce0eb9d40ad7fb5e14c2e',
+    'windows-amd64': '9589bd307b4a908beaf65c6887f675090a8299f47979447e49a3b2a78d07a1d8',
+    'windows-arm64': '746adc54325d82e080c32501e17f66cd1830e937bc496026eb155c06cc6fd257',
+    'windows-armv7': '855007017fd5c2043ada6d43d21eb74e1cad8d496a74476be8af9e33bce296bc',
 }
 
 
@@ -230,15 +235,22 @@ def _platform_tag() -> str:
 
 def _binary_url() -> str:
     """Resolve the binary archive URL.  `LIVEKIT_BINARY_URL` lets ISO /
-    air-gapped builds point at a local mirror or cached file://."""
+    air-gapped builds point at a local mirror or cached file://.
+
+    LiveKit's release filenames use underscore between os and arch
+    (`livekit_1.7.2_linux_amd64.tar.gz`), but our internal platform
+    tag uses hyphen (`linux-amd64`) since it doubles as a dict key in
+    _LIVEKIT_SHA256.  The translation happens here.
+    """
     override = os.environ.get('LIVEKIT_BINARY_URL')
     if override:
         return override
-    tag = _platform_tag()
+    tag = _platform_tag()                  # e.g. 'linux-amd64'
+    url_tag = tag.replace('-', '_')        # e.g. 'linux_amd64'
     ext = 'zip' if tag.startswith('windows-') else 'tar.gz'
     return (
         f'https://github.com/livekit/livekit/releases/download/'
-        f'v{LIVEKIT_VERSION}/livekit_{LIVEKIT_VERSION}_{tag}.{ext}'
+        f'v{LIVEKIT_VERSION}/livekit_{LIVEKIT_VERSION}_{url_tag}.{ext}'
     )
 
 

--- a/integrations/social/room_presence_service.py
+++ b/integrations/social/room_presence_service.py
@@ -1,0 +1,334 @@
+"""
+room_presence_service — UNIF-G6 — canonical agent-presence-in-external-room policy.
+
+This module is the single writer for the three policies that MUST stay
+together when an AI agent participates in an external room (Discord
+audio, Teams meet, WhatsApp group, Slack channel, Matrix room,
+Telegram supergroup, etc.):
+
+  1. ``gate(...)``        — consent check before joining
+  2. ``announce_presence(...)`` — required notice posted into the room
+  3. ``listen_for_objection(...)`` — auto-detach if anyone says "no AI"
+
+Per HIVE AI MISSION (memory/project_hive_mission.md): the agent NEVER
+silently observes external rooms.  Three guardrails:
+   - Consent before join (UI prompt or pre-granted scope).
+   - Announcement on join (every participant sees a clearly-flagged
+     notice that an AI is present, who it serves, and how to remove it).
+   - Listen for objection — if any participant uses an opt-out phrase
+     in any of the supported languages, the agent posts a farewell and
+     leaves immediately.
+
+Canonical primitives reused (no parallel paths):
+   - ``ConsentService.check_consent`` — gate decision (consent_type
+     ``'cloud_capability'`` + scope ``agent_joins_external_room`` etc.)
+   - ``ChannelAdapter.send_message`` — post the announcement into the room
+   - ``ImmutableAuditLog.log_event`` — durable audit chain for join/leave
+   - ``AgentVoiceBridge.detach_agent`` — voice-room detach on objection
+
+Caller (G2 ``Join_External_Room`` agent tool) is responsible for
+calling ``gate`` BEFORE invoking the adapter join, then
+``announce_presence`` immediately after a successful join, then
+``listen_for_objection`` to wire the objection-watcher.
+
+This module is intentionally agnostic of which platform — every
+platform that supports text messaging exposes
+``ChannelAdapter.send_message``, so the announce + farewell flows
+through one code path.  Voice rooms (livekit) get their detach via the
+existing ``AgentVoiceBridge`` (line 239 ``detach_agent``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+logger = logging.getLogger('hevolve_social')
+
+# ── Consent scopes per role ────────────────────────────────────────
+# The role determines which scope we check.  These string literals
+# MUST stay in sync with ``landing-page/src/components/Social/Settings/
+# cloudCapabilityScopes.js:CLOUD_CAPABILITY_SCOPES``.
+_SCOPE_BY_ROLE = {
+    'note_taker': 'agent_listens_external_audio',
+    'co_pilot': 'agent_joins_external_room',
+    'participant': 'agent_joins_external_room',
+    'silent_observer': 'agent_joins_external_room',
+    'writer': 'agent_writes_external_room',
+}
+_DEFAULT_SCOPE = 'agent_joins_external_room'
+_CONSENT_TYPE = 'cloud_capability'
+
+# ── Objection phrases (i18n) ───────────────────────────────────────
+# Any participant typing one of these (case-insensitive, word-boundary)
+# triggers immediate agent detach + farewell.  Adding a language: append
+# the phrase here.  Single source of truth — no per-adapter copy.
+_OBJECTION_PHRASES = (
+    # English
+    'no ai', 'no bot', 'no agent', 'remove ai', 'remove bot',
+    'kick the ai', 'kick the bot', '/agent-out',
+    # Spanish
+    'sin ia', 'no ia', 'fuera ia', 'sin bot',
+    # French
+    'pas d\'ia', 'sans ia', 'pas de bot',
+    # German
+    'keine ki', 'kein bot', 'ki raus',
+    # Hindi (Latin script)
+    'no ai please', 'ai hata',
+    # Mandarin (transliteration + simplified)
+    'wu ai', '不要 ai',
+    # Japanese
+    'ai なし',
+    # Portuguese
+    'sem ia', 'fora ia',
+    # Tamil (Latin)
+    'ai venda',
+)
+
+
+def _scope_for_role(role: str) -> str:
+    """Map a join role to the consent scope it requires."""
+    return _SCOPE_BY_ROLE.get((role or '').lower(), _DEFAULT_SCOPE)
+
+
+def gate(user_id: str, platform: str, room_id: str,
+         role: str = 'co_pilot') -> Tuple[bool, str]:
+    """Return ``(allowed, reason)`` for an agent-in-room join.
+
+    Checks ``ConsentService.check_consent`` against the appropriate
+    cloud-capability scope for the requested role.  Caller (G2 agent
+    tool) is responsible for surfacing a Liquid UI consent prompt
+    when this returns ``(False, ...)``.
+
+    Failure modes (all return ``(False, <reason>)`` not raise):
+      - DB unavailable / consent service import fails → assume DENIED
+        (fail-closed; never auto-grant).
+      - User has revoked the scope → DENIED.
+      - User never granted → DENIED, with reason ``'consent required'``
+        so caller can prompt.
+
+    Audit trail: every gate decision (allow OR deny) emits an audit log
+    entry via ``ImmutableAuditLog.log_event`` so security review can
+    reconstruct who allowed what when.  Never raises.
+    """
+    scope = _scope_for_role(role)
+    detail = {
+        'platform': platform,
+        'room_id': room_id,
+        'role': role,
+        'scope': scope,
+    }
+    try:
+        from integrations.social.consent_service import ConsentService
+        from integrations.social.models import get_db
+        db = get_db()
+        try:
+            allowed = ConsentService.check_consent(
+                db, str(user_id), _CONSENT_TYPE, scope=scope)
+        finally:
+            db.close()
+    except Exception as e:
+        logger.warning(
+            "room_presence.gate: consent check failed for "
+            "user=%s scope=%s platform=%s room=%s: %s — failing closed",
+            user_id, scope, platform, room_id, e)
+        _audit('room_presence.gate', user_id, 'denied_error',
+               {**detail, 'error': str(e)[:200]})
+        return False, 'consent service unavailable — please retry'
+
+    if allowed:
+        _audit('room_presence.gate', user_id, 'allowed', detail)
+        return True, 'ok'
+    _audit('room_presence.gate', user_id, 'denied_no_consent', detail)
+    return False, (
+        f"Permission required: I need your consent to "
+        f"join {platform} rooms as a {role}. Please grant the "
+        f"'{scope}' scope in Settings → Privacy."
+    )
+
+
+def announce_presence(adapter, room_id: str, user_id: str,
+                      role: str = 'co_pilot',
+                      *, owner_display_name: Optional[str] = None) -> bool:
+    """Post the canonical announcement message into the external room.
+
+    Honors HIVE AI MISSION rule that the agent ALWAYS makes its
+    presence known.  Wording is fixed (single canon — no per-platform
+    variant) so users see consistent disclosure across Discord / Teams
+    / WhatsApp / etc.
+
+    Args:
+        adapter:  A ``ChannelAdapter`` instance (must support
+                  ``send_message`` per ``channels/base.py:141``).
+        room_id:  Platform-native room/chat id.
+        user_id:  Owner's user id (for the audit log).
+        role:     Same role string used in ``gate()``.
+        owner_display_name: Optional friendly name to insert into
+                  the announcement.  Falls back to "this user".
+
+    Returns ``True`` iff the announcement was sent successfully.
+    On failure, audit logs the error and returns ``False`` — the
+    caller (G2) MUST treat that as a hard failure and DETACH the
+    agent rather than continuing silently.
+    """
+    name = owner_display_name or 'this user'
+    role_label = {
+        'note_taker': 'note-taker',
+        'co_pilot': 'co-pilot',
+        'participant': 'participant',
+        'silent_observer': 'silent observer (read-only)',
+        'writer': 'message writer',
+    }.get((role or '').lower(), 'co-pilot')
+
+    text = (
+        f"\U0001F916 An AI agent has joined this room as {name}'s "
+        f"{role_label}. It will follow the conversation to help "
+        f"with notes / answers. Reply 'no AI' (or '/agent-out') "
+        f"any time to have it leave."
+    )
+    detail = {
+        'platform': getattr(adapter, 'name', '?'),
+        'room_id': room_id, 'role': role,
+    }
+    try:
+        import asyncio
+        # ChannelAdapter.send_message is async; the caller may already
+        # be inside an event loop (Flask + asyncio mix).  Defer to the
+        # adapter's registry loop when present, else run a one-shot.
+        coro = adapter.send_message(room_id, text)
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                fut = asyncio.run_coroutine_threadsafe(coro, loop)
+                result = fut.result(timeout=10)
+            else:
+                result = loop.run_until_complete(coro)
+        except RuntimeError:
+            result = asyncio.run(coro)
+        ok = bool(getattr(result, 'success', False))
+        _audit('room_presence.announce', user_id,
+               'announced' if ok else 'announce_failed',
+               {**detail, 'message_id': getattr(result, 'message_id', None)})
+        return ok
+    except Exception as e:
+        logger.warning(
+            "room_presence.announce_presence failed (platform=%s "
+            "room=%s): %s", detail['platform'], room_id, e)
+        _audit('room_presence.announce', user_id, 'announce_error',
+               {**detail, 'error': str(e)[:200]})
+        return False
+
+
+def is_objection(text: str) -> bool:
+    """Return True iff ``text`` contains a known objection phrase.
+
+    Pure helper — no side effects.  Used by ``listen_for_objection``
+    and reusable for unit tests.  Case-insensitive substring match;
+    the phrases are short enough that false positives are negligible
+    (a bystander typing "no ai" verbatim DOES want the agent to leave).
+    """
+    if not text:
+        return False
+    low = text.lower()
+    return any(p in low for p in _OBJECTION_PHRASES)
+
+
+def listen_for_objection(adapter, room_id: str, user_id: str,
+                         agent_id: str,
+                         *, on_detach=None) -> None:
+    """Hook ``adapter.on_message`` to watch for objection phrases.
+
+    On match: logs the objection, posts a brief farewell into the
+    room (best-effort, never blocks), invokes ``on_detach`` callback
+    so the caller can run platform-specific detach (e.g.
+    ``AgentVoiceBridge.detach_agent`` for voice rooms,
+    ``adapter.leave_room`` for text rooms when G2 ships the Mixin).
+
+    Caller signature for ``on_detach``: ``on_detach(reason: str) -> None``.
+    Best-effort — exceptions from the callback are logged, never raised.
+
+    Note: this function REGISTERS a handler on the adapter; it does
+    NOT block.  The handler stays active until the adapter unregisters
+    it (which happens automatically when the adapter disconnects).
+    """
+    if adapter is None or not hasattr(adapter, 'on_message'):
+        logger.debug(
+            "room_presence.listen_for_objection: adapter %r lacks "
+            "on_message hook — skipping", adapter)
+        return
+
+    detail = {
+        'platform': getattr(adapter, 'name', '?'),
+        'room_id': room_id, 'agent_id': agent_id,
+    }
+
+    async def _check_objection(message):
+        try:
+            text = getattr(message, 'text', '') or ''
+            chat_id = getattr(message, 'chat_id', None)
+            if chat_id and str(chat_id) != str(room_id):
+                return
+            if not is_objection(text):
+                return
+            logger.info(
+                "room_presence: objection detected in %s/%s — "
+                "detaching agent %s", detail['platform'], room_id, agent_id)
+            _audit('room_presence.objection', user_id, 'detected',
+                   {**detail, 'phrase_in': text[:120]})
+            # Farewell — best-effort.
+            try:
+                farewell = (
+                    "\U0001F44B Understood — leaving now. "
+                    "Re-invite anytime."
+                )
+                await adapter.send_message(room_id, farewell)
+            except Exception as fe:
+                logger.debug(
+                    "room_presence: farewell post failed: %s", fe)
+            # Caller-supplied detach.
+            if callable(on_detach):
+                try:
+                    on_detach('participant_objection')
+                except Exception as de:
+                    logger.warning(
+                        "room_presence: on_detach callback raised: %s", de)
+                    _audit('room_presence.detach', user_id,
+                           'detach_callback_error',
+                           {**detail, 'error': str(de)[:200]})
+            else:
+                _audit('room_presence.detach', user_id,
+                       'no_detach_callback', detail)
+        except Exception as e:
+            # Never let a watcher error break adapter delivery.
+            logger.warning(
+                "room_presence.listen_for_objection inner: %s", e)
+
+    try:
+        adapter.on_message(_check_objection)
+        _audit('room_presence.watch', user_id, 'watcher_attached', detail)
+    except Exception as e:
+        logger.warning(
+            "room_presence.listen_for_objection: failed to attach "
+            "watcher: %s", e)
+        _audit('room_presence.watch', user_id, 'watcher_attach_failed',
+               {**detail, 'error': str(e)[:200]})
+
+
+def _audit(event_type: str, actor_id: str, action: str, detail: dict) -> None:
+    """Best-effort audit log emit.  Never raises."""
+    try:
+        from security.immutable_audit_log import get_audit_log
+        get_audit_log().log_event(
+            event_type=event_type,
+            actor_id=str(actor_id),
+            action=action,
+            detail=detail,
+        )
+    except Exception as e:
+        # Audit log unavailable — log to module logger so a grep over
+        # the local log file still surfaces it.  Don't escalate;
+        # consent / announce / listen flows must keep going.
+        logger.info(
+            "room_presence audit (fallback): %s/%s actor=%s detail=%s "
+            "(audit_log error: %s)",
+            event_type, action, actor_id, detail, e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,15 @@ dependencies = [
     "tqdm>=4.65.0,<5.0.0",
     "coloredlogs>=15.0.0,<16.0.0",
     "PyYAML>=6.0,<7.0",
+
+    # LiveKit (Phase 7d.B) — voice/video/screen-share SFU.
+    # Hard dep so `pip install -e .` includes the JWT-signing SDK
+    # by default; the LiveKitService auto-generates dev keys when
+    # LIVEKIT_API_KEY/SECRET aren't set, so flat/regional installs
+    # work without manual provisioning.  External SFU (LiveKit
+    # Cloud or self-hosted livekit-server binary) is a separate
+    # piece of infra; HARTOS only ships the token issuer.
+    "livekit-api>=0.7.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ dependencies = [
     # work without manual provisioning.  External SFU (LiveKit
     # Cloud or self-hosted livekit-server binary) is a separate
     # piece of infra; HARTOS only ships the token issuer.
-    "livekit-api>=0.7.0,<2.0.0",
+    "livekit-api>=1.0.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,6 +76,8 @@ langchain-google-genai==4.2.1
 langchain-groq==1.1.2
 langsmith==0.3.45
 lit==16.0.6
+livekit-api==0.7.6
+livekit-protocol==0.6.4
 lz4==4.3.2
 MarkupSafe==2.1.3
 marshmallow==3.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,8 +76,8 @@ langchain-google-genai==4.2.1
 langchain-groq==1.1.2
 langsmith==0.3.45
 lit==16.0.6
-livekit-api==0.7.6
-livekit-protocol==0.6.4
+livekit-api==1.0.7
+livekit-protocol==1.1.8
 lz4==4.3.2
 MarkupSafe==2.1.3
 marshmallow==3.19.0

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ install_requires = [
     # Hard dep so every build target (pip / ISO / Docker / PEX) gets
     # the JWT signer.  Dev-key bootstrap in livekit_service handles the
     # config side automatically — see ~/.hevolve/livekit_dev.json.
-    "livekit-api>=0.7.0,<2.0.0",
+    "livekit-api>=1.0.0,<2.0.0",
 ]
 
 # Optional dependencies for specific features

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,12 @@ install_requires = [
     "tqdm>=4.65.0,<5.0.0",
     "coloredlogs>=15.0.0,<16.0.0",
     "PyYAML>=6.0,<7.0",
+
+    # LiveKit (Phase 7d.B) — voice/video/screen-share SFU token signer.
+    # Hard dep so every build target (pip / ISO / Docker / PEX) gets
+    # the JWT signer.  Dev-key bootstrap in livekit_service handles the
+    # config side automatically — see ~/.hevolve/livekit_dev.json.
+    "livekit-api>=0.7.0,<2.0.0",
 ]
 
 # Optional dependencies for specific features

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -50,6 +50,11 @@ ENV TESTING=true
 ENV FLASK_ENV=testing
 ENV REDIS_HOST=redis
 ENV REDIS_PORT=6379
+# LiveKit supervisor stays off during tests — no binary fetch / no port
+# bind, no flake from unavailable network or port collisions.  Tests
+# that need to exercise supervisor branches set HEVOLVE_DEPLOY_MODE=flat
+# and HEVOLVE_HOME=<tmp> via monkeypatch (see test_phase7d_calls.py).
+ENV LIVEKIT_DISABLE=1
 
 # Create a non-root user for testing
 RUN useradd -m -u 1000 testuser && \

--- a/tests/e2e/test_e2e_pipelines.py
+++ b/tests/e2e/test_e2e_pipelines.py
@@ -348,7 +348,7 @@ class TestDaemonTickIntegration:
     """E2E: daemon _tick() with goals + idle agents + milestone + quota reset."""
 
     @patch('integrations.agent_engine.dispatch.dispatch_goal')
-    @patch('integrations.coding_agent.idle_detection.IdleDetectionService.get_idle_opted_in_agents')
+    @patch('integrations.coding_agent.idle_detection.IdleDetectionService.get_idle_agent_personas')
     def test_tick_dispatches_to_idle_agent(self, mock_idle, mock_dispatch, db, idle_agent):
         """Active goal + idle agent → dispatch_goal called."""
         from integrations.agent_engine.agent_daemon import AgentDaemon
@@ -379,7 +379,7 @@ class TestDaemonTickIntegration:
         assert str(idle_agent.id) in str(call_args)
 
     @patch('integrations.agent_engine.dispatch.dispatch_goal')
-    @patch('integrations.coding_agent.idle_detection.IdleDetectionService.get_idle_opted_in_agents')
+    @patch('integrations.coding_agent.idle_detection.IdleDetectionService.get_idle_agent_personas')
     def test_tick_no_goals_no_dispatch(self, mock_idle, mock_dispatch, db):
         """No active goals → no dispatch."""
         from integrations.agent_engine.agent_daemon import AgentDaemon

--- a/tests/test_phase7d_calls.py
+++ b/tests/test_phase7d_calls.py
@@ -796,6 +796,58 @@ def test_operational_thresholds_match_api_calls_defaults():
     assert OPERATIONAL_THRESHOLDS == _DEFAULT_KIND_THRESHOLDS
 
 
+def test_supervisor_binary_url_uses_underscore_separator(monkeypatch):
+    """LiveKit's release filenames use `linux_amd64`, not `linux-amd64`.
+    Our internal platform tag uses hyphen (doubles as dict key) — the
+    URL builder must translate hyphen → underscore."""
+    monkeypatch.delenv('LIVEKIT_BINARY_URL', raising=False)
+    from integrations.social import livekit_supervisor
+    # Pin platform.system / machine for deterministic URL.
+    monkeypatch.setattr(livekit_supervisor.platform, 'system',
+                        lambda: 'Linux')
+    monkeypatch.setattr(livekit_supervisor.platform, 'machine',
+                        lambda: 'x86_64')
+    url = livekit_supervisor._binary_url()
+    assert 'livekit_1.7.2_linux_amd64.tar.gz' in url
+    assert 'linux-amd64' not in url
+
+
+def test_supervisor_binary_url_windows_uses_zip(monkeypatch):
+    monkeypatch.delenv('LIVEKIT_BINARY_URL', raising=False)
+    from integrations.social import livekit_supervisor
+    monkeypatch.setattr(livekit_supervisor.platform, 'system',
+                        lambda: 'Windows')
+    monkeypatch.setattr(livekit_supervisor.platform, 'machine',
+                        lambda: 'AMD64')
+    url = livekit_supervisor._binary_url()
+    assert url.endswith('windows_amd64.zip')
+
+
+def test_supervisor_binary_url_override_env(monkeypatch):
+    """LIVEKIT_BINARY_URL bypasses URL construction (air-gapped /
+    mirror / file:// builds)."""
+    monkeypatch.setenv('LIVEKIT_BINARY_URL',
+                       'file:///cache/livekit-1.7.2.tar.gz')
+    from integrations.social import livekit_supervisor
+    assert livekit_supervisor._binary_url() == 'file:///cache/livekit-1.7.2.tar.gz'
+
+
+def test_supervisor_sha256_pinned_for_supported_platforms():
+    """Supply-chain integrity: every platform we build a download URL
+    for must have a non-empty SHA-256 pin.  Adding a new platform tag
+    without pinning its hash is a CI-breaking mistake."""
+    from integrations.social.livekit_supervisor import _LIVEKIT_SHA256
+    expected_keys = {
+        'linux-amd64', 'linux-arm64', 'linux-armv7',
+        'windows-amd64', 'windows-arm64', 'windows-armv7',
+    }
+    for key in expected_keys:
+        assert key in _LIVEKIT_SHA256, f'missing SHA-256 pin for {key}'
+        # Real SHA-256 hex is 64 chars; empty would skip verification.
+        assert len(_LIVEKIT_SHA256[key]) == 64, (
+            f'SHA-256 pin for {key} is empty or wrong length')
+
+
 def test_decide_media_mode_excludes_left_participants(monkeypatch):
     """Active count uses left_at IS NULL — left rows don't count."""
     monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)

--- a/tests/test_phase7d_calls.py
+++ b/tests/test_phase7d_calls.py
@@ -691,6 +691,111 @@ def test_decide_media_mode_threshold_override(monkeypatch):
     assert _decide_media_mode(sess, parts2, is_agent=False) == 'livekit'
 
 
+def test_decide_media_mode_video_uses_tighter_default(monkeypatch):
+    """Video crosses to SFU at N=4 (default 3) — one peer earlier than
+    voice (default 4).  The bandwidth model justifies this: 500 kbps ×
+    3 = 1.5 Mbps mesh upload at N=4, which saturates a typical
+    residential uplink."""
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD_VIDEO', raising=False)
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD_VOICE', raising=False)
+    _patch_g_user(monkeypatch)
+    from integrations.social.api_calls import _decide_media_mode
+    # 3 participants total (caller + 2 others) → at video threshold
+    parts = [{'user_id': 'u1', 'left_at': None},
+             {'user_id': 'u2', 'left_at': None}]
+    assert _decide_media_mode({'kind': 'video'}, parts,
+                              is_agent=False) == 'p2p_mesh'
+    # 4 participants → over video threshold (3)
+    parts4 = parts + [{'user_id': 'u3', 'left_at': None}]
+    assert _decide_media_mode({'kind': 'video'}, parts4,
+                              is_agent=False) == 'livekit'
+    # Same N=4 on a voice call still mesh (voice threshold = 4)
+    assert _decide_media_mode({'kind': 'voice'}, parts4,
+                              is_agent=False) == 'p2p_mesh'
+
+
+def test_decide_media_mode_per_kind_env_override(monkeypatch):
+    """LIVEKIT_MESH_THRESHOLD_VOICE / _VIDEO override per-kind."""
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)
+    monkeypatch.setenv('LIVEKIT_MESH_THRESHOLD_VIDEO', '6')
+    _patch_g_user(monkeypatch)
+    from integrations.social.api_calls import _decide_media_mode
+    # 5 video participants — would default to SFU (>3), but per-kind
+    # override allows mesh up to 6.
+    parts = [{'user_id': f'u{i}', 'left_at': None} for i in range(4)]
+    assert _decide_media_mode({'kind': 'video'}, parts,
+                              is_agent=False) == 'p2p_mesh'
+
+
+def test_decide_media_mode_uniform_env_overrides_per_kind(monkeypatch):
+    """LIVEKIT_MESH_THRESHOLD (uniform) takes precedence over the
+    per-kind default but loses to the per-kind override."""
+    monkeypatch.setenv('LIVEKIT_MESH_THRESHOLD', '2')
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD_VOICE', raising=False)
+    _patch_g_user(monkeypatch)
+    from integrations.social.api_calls import _decide_media_mode
+    # 3 voice participants (caller + 2) — over uniform threshold of 2
+    parts = [{'user_id': 'u1', 'left_at': None},
+             {'user_id': 'u2', 'left_at': None}]
+    assert _decide_media_mode({'kind': 'voice'}, parts,
+                              is_agent=False) == 'livekit'
+
+
+def test_mesh_threshold_unknown_kind_falls_back(monkeypatch):
+    """An unknown kind (not in _DEFAULT_KIND_THRESHOLDS) falls back to
+    the conservative 4 — no KeyError, no NaN."""
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)
+    from integrations.social.api_calls import _mesh_threshold
+    assert _mesh_threshold('weird_unknown_kind') == 4
+
+
+def test_mesh_threshold_garbage_env_falls_back(monkeypatch):
+    """Non-numeric env values fall back to the default per-kind."""
+    monkeypatch.setenv('LIVEKIT_MESH_THRESHOLD', 'not-a-number')
+    from integrations.social.api_calls import _mesh_threshold
+    # voice default is 4 from _DEFAULT_KIND_THRESHOLDS
+    assert _mesh_threshold('voice') == 4
+
+
+def test_bandwidth_model_crossover_table():
+    """Sanity-check the bandwidth model: mesh upload grows linearly,
+    SFU upload stays flat."""
+    from integrations.social._mesh_bandwidth_model import crossover_table
+    table = crossover_table('video', max_n=5)
+    assert table[2].mesh_up_kbps == 500   # 1 peer × 500 kbps
+    assert table[3].mesh_up_kbps == 1000
+    assert table[4].mesh_up_kbps == 1500
+    assert table[5].mesh_up_kbps == 2000
+    # SFU upload stays flat at one stream regardless of N
+    for n in range(2, 6):
+        assert table[n].sfu_up_kbps == 500
+
+
+def test_bandwidth_model_first_n_above_ceiling():
+    """1500 kbps uplink with VP8 video — mesh fits through N=4
+    (1500 kbps mesh upload), exceeds at N=5."""
+    from integrations.social._mesh_bandwidth_model import (
+        first_n_where_mesh_upload_exceeds,
+    )
+    # video at N=4 = 1500 kbps == ceiling (not >), so first exceeding N
+    # is 5.
+    assert first_n_where_mesh_upload_exceeds('video', 1500) == 5
+    # voice is so cheap it never exceeds even at N=46 (45 × 32 = 1440)
+    # but at N=47 it's 1472, still under.  At N=48: 1504 — exceeds.
+    assert first_n_where_mesh_upload_exceeds('voice', 1500) == 48
+
+
+def test_operational_thresholds_match_api_calls_defaults():
+    """The model's documented operational thresholds must equal the
+    constants in api_calls.  If you change one, change the other."""
+    from integrations.social._mesh_bandwidth_model import (
+        OPERATIONAL_THRESHOLDS,
+    )
+    from integrations.social.api_calls import _DEFAULT_KIND_THRESHOLDS
+    assert OPERATIONAL_THRESHOLDS == _DEFAULT_KIND_THRESHOLDS
+
+
 def test_decide_media_mode_excludes_left_participants(monkeypatch):
     """Active count uses left_at IS NULL — left rows don't count."""
     monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)

--- a/tests/test_phase7d_calls.py
+++ b/tests/test_phase7d_calls.py
@@ -427,14 +427,19 @@ def test_attach_agent_without_grant_refused(fresh_db):
 
 # ── LiveKit token issuance ─────────────────────────────────────────
 
-def test_token_falls_back_to_p2p_when_no_livekit_config(monkeypatch):
-    """Flat / regional / Nunba bundled have LIVEKIT_URL unset.
-    issue_token must return mode='p2p_mesh' so clients run a WebRTC
-    P2P mesh signaled over PeerLink instead of trying to connect to
-    a non-existent LiveKit instance."""
+def test_token_falls_back_to_p2p_when_supervisor_disabled(monkeypatch):
+    """Central / embedded deploys (LIVEKIT_DISABLE=1 or
+    HEVOLVE_DEPLOY_MODE=central) do NOT host an SFU.  When env vars
+    are unset AND the supervisor is disabled, issue_token returns
+    mode='p2p_mesh' so clients run a WebRTC P2P mesh signaled over
+    PeerLink instead of trying to connect to a non-existent SFU.
+
+    (Flat/regional deploys auto-provision dev keys via the supervisor
+    — see test_token_uses_supervisor_dev_keys_on_flat below.)"""
     monkeypatch.delenv('LIVEKIT_URL', raising=False)
     monkeypatch.delenv('LIVEKIT_API_KEY', raising=False)
     monkeypatch.delenv('LIVEKIT_API_SECRET', raising=False)
+    monkeypatch.setenv('LIVEKIT_DISABLE', '1')
     from integrations.social.livekit_service import LiveKitService
     r = LiveKitService.issue_token('call-1', 'user-1')
     assert r['mode'] == 'p2p_mesh'
@@ -455,6 +460,28 @@ def test_token_uses_livekit_when_configured(monkeypatch):
     assert r['mode'] in ('livekit', 'livekit_pending')
     assert r['url'] == 'wss://livekit.example'
     assert r['metadata']['agent_kind'] == 'agent'
+
+
+def test_token_uses_supervisor_dev_keys_on_flat(monkeypatch, tmp_path):
+    """Flat/regional deploys auto-provision LiveKit dev keys via the
+    supervisor.  With env vars unset, issue_token must reach a working
+    config from the supervisor's auto-generated keys (no manual setup
+    needed) — mode is 'livekit' (real JWT) or 'livekit_pending' (SDK
+    not installed).  Dev keys + URL come from livekit_supervisor."""
+    monkeypatch.delenv('LIVEKIT_URL', raising=False)
+    monkeypatch.delenv('LIVEKIT_API_KEY', raising=False)
+    monkeypatch.delenv('LIVEKIT_API_SECRET', raising=False)
+    monkeypatch.delenv('LIVEKIT_DISABLE', raising=False)
+    monkeypatch.delenv('LIVEKIT_AUTOSTART', raising=False)
+    monkeypatch.setenv('HEVOLVE_DEPLOY_MODE', 'flat')
+    monkeypatch.setenv('HEVOLVE_HOME', str(tmp_path))
+    from integrations.social.livekit_service import LiveKitService
+    r = LiveKitService.issue_token('call-1', 'user-1')
+    # Either signed JWT (SDK installed) or pending shape (SDK absent)
+    # — both confirm the supervisor's config flowed through.
+    assert r['mode'] in ('livekit', 'livekit_pending')
+    assert r.get('url', '').startswith('ws://localhost:')
+    assert 'metadata' in r
 
 
 # ── REST surface ──────────────────────────────────────────────────
@@ -588,3 +615,177 @@ def test_create_agent_grant_endpoint(app_client):
     body = r.get_json()
     assert body['data']['agent_id'] == agent.id
     assert body['data']['scope']['can_voice'] is True
+
+
+# ── _decide_media_mode mesh-first promotion (Task #275) ─────────────
+# Validates the "PeerLink ↔ LiveKit complement" branches.  Empirical
+# threshold benchmarking is queued under #276; these tests just lock
+# in the current contract so #276 can compare against a baseline.
+
+class _FakeUser:
+    def __init__(self, uid):
+        self.id = uid
+
+
+def _patch_g_user(monkeypatch, uid='caller-1'):
+    """Stub flask.g.user for _decide_media_mode caller-id resolution."""
+    from integrations.social import api_calls
+    class _G:
+        user = _FakeUser(uid)
+    monkeypatch.setattr(api_calls, 'g', _G)
+
+
+def test_decide_media_mode_voice_under_threshold(monkeypatch):
+    """≤4 active voice participants → p2p_mesh (PeerLink-signaled)."""
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)
+    _patch_g_user(monkeypatch)
+    from integrations.social.api_calls import _decide_media_mode
+    sess = {'kind': 'voice'}
+    parts = [{'user_id': 'u1', 'left_at': None},
+             {'user_id': 'u2', 'left_at': None}]
+    assert _decide_media_mode(sess, parts, is_agent=False) == 'p2p_mesh'
+
+
+def test_decide_media_mode_voice_over_threshold(monkeypatch):
+    """>4 active participants → livekit (mesh fanout becomes inefficient)."""
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)
+    _patch_g_user(monkeypatch)
+    from integrations.social.api_calls import _decide_media_mode
+    sess = {'kind': 'voice'}
+    # 4 already in + caller about to join = 5 active → over threshold(=4)
+    parts = [{'user_id': f'u{i}', 'left_at': None} for i in range(4)]
+    assert _decide_media_mode(sess, parts, is_agent=False) == 'livekit'
+
+
+def test_decide_media_mode_agent_always_livekit(monkeypatch):
+    """Any agent participant → livekit (AgentVoiceBridge needs SFU)."""
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)
+    _patch_g_user(monkeypatch)
+    from integrations.social.api_calls import _decide_media_mode
+    sess = {'kind': 'voice'}
+    assert _decide_media_mode(sess, [], is_agent=True) == 'livekit'
+
+
+def test_decide_media_mode_screen_share_always_livekit(monkeypatch):
+    """screen_share / mixed kinds → livekit regardless of count."""
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)
+    _patch_g_user(monkeypatch)
+    from integrations.social.api_calls import _decide_media_mode
+    assert _decide_media_mode({'kind': 'screen_share'}, [],
+                              is_agent=False) == 'livekit'
+    assert _decide_media_mode({'kind': 'mixed'}, [],
+                              is_agent=False) == 'livekit'
+
+
+def test_decide_media_mode_threshold_override(monkeypatch):
+    """LIVEKIT_MESH_THRESHOLD=999 keeps everything on mesh; =0 forces SFU."""
+    _patch_g_user(monkeypatch)
+    from integrations.social.api_calls import _decide_media_mode
+    sess = {'kind': 'voice'}
+    parts = [{'user_id': f'u{i}', 'left_at': None} for i in range(20)]
+    monkeypatch.setenv('LIVEKIT_MESH_THRESHOLD', '999')
+    assert _decide_media_mode(sess, parts, is_agent=False) == 'p2p_mesh'
+    monkeypatch.setenv('LIVEKIT_MESH_THRESHOLD', '0')
+    # Threshold clamped to min 1, so 1 person mesh; 2 → livekit.
+    parts2 = [{'user_id': 'u1', 'left_at': None}]
+    assert _decide_media_mode(sess, parts2, is_agent=False) == 'livekit'
+
+
+def test_decide_media_mode_excludes_left_participants(monkeypatch):
+    """Active count uses left_at IS NULL — left rows don't count."""
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)
+    _patch_g_user(monkeypatch)
+    from integrations.social.api_calls import _decide_media_mode
+    sess = {'kind': 'voice'}
+    # 5 entries but 3 left → 2 active + 1 caller = 3 → mesh
+    parts = [{'user_id': 'u1', 'left_at': None},
+             {'user_id': 'u2', 'left_at': None},
+             {'user_id': 'u3', 'left_at': '2026-05-07T10:00:00Z'},
+             {'user_id': 'u4', 'left_at': '2026-05-07T10:01:00Z'},
+             {'user_id': 'u5', 'left_at': '2026-05-07T10:02:00Z'}]
+    assert _decide_media_mode(sess, parts, is_agent=False) == 'p2p_mesh'
+
+
+def test_decide_media_mode_caller_already_active_no_double_count(monkeypatch):
+    """If caller is already in the participant list, don't add +1."""
+    monkeypatch.delenv('LIVEKIT_MESH_THRESHOLD', raising=False)
+    _patch_g_user(monkeypatch, uid='caller-1')
+    from integrations.social.api_calls import _decide_media_mode
+    sess = {'kind': 'voice'}
+    # 4 active including caller → at threshold (4), not over
+    parts = [{'user_id': 'caller-1', 'left_at': None},
+             {'user_id': 'u2', 'left_at': None},
+             {'user_id': 'u3', 'left_at': None},
+             {'user_id': 'u4', 'left_at': None}]
+    assert _decide_media_mode(sess, parts, is_agent=False) == 'p2p_mesh'
+
+
+# ── Supervisor branch tests (Task #275) ─────────────────────────────
+
+def test_supervisor_should_run_central_returns_false(monkeypatch):
+    monkeypatch.setenv('HEVOLVE_DEPLOY_MODE', 'central')
+    monkeypatch.delenv('LIVEKIT_AUTOSTART', raising=False)
+    monkeypatch.delenv('LIVEKIT_DISABLE', raising=False)
+    from integrations.social import livekit_supervisor
+    assert livekit_supervisor.supervisor_should_run() is False
+
+
+def test_supervisor_should_run_flat_returns_true(monkeypatch):
+    monkeypatch.setenv('HEVOLVE_DEPLOY_MODE', 'flat')
+    monkeypatch.delenv('LIVEKIT_AUTOSTART', raising=False)
+    monkeypatch.delenv('LIVEKIT_DISABLE', raising=False)
+    from integrations.social import livekit_supervisor
+    assert livekit_supervisor.supervisor_should_run() is True
+
+
+def test_supervisor_disable_env_overrides_mode(monkeypatch):
+    monkeypatch.setenv('HEVOLVE_DEPLOY_MODE', 'flat')
+    monkeypatch.setenv('LIVEKIT_DISABLE', '1')
+    monkeypatch.delenv('LIVEKIT_AUTOSTART', raising=False)
+    from integrations.social import livekit_supervisor
+    assert livekit_supervisor.supervisor_should_run() is False
+
+
+def test_supervisor_autostart_env_overrides_mode(monkeypatch):
+    """LIVEKIT_AUTOSTART=1 forces supervisor on regardless of deploy mode."""
+    monkeypatch.setenv('HEVOLVE_DEPLOY_MODE', 'central')
+    monkeypatch.setenv('LIVEKIT_AUTOSTART', '1')
+    monkeypatch.delenv('LIVEKIT_DISABLE', raising=False)
+    from integrations.social import livekit_supervisor
+    assert livekit_supervisor.supervisor_should_run() is True
+
+
+def test_supervisor_autostart_zero_overrides_mode(monkeypatch):
+    """LIVEKIT_AUTOSTART=0 forces supervisor off regardless of deploy mode."""
+    monkeypatch.setenv('HEVOLVE_DEPLOY_MODE', 'flat')
+    monkeypatch.setenv('LIVEKIT_AUTOSTART', '0')
+    monkeypatch.delenv('LIVEKIT_DISABLE', raising=False)
+    from integrations.social import livekit_supervisor
+    assert livekit_supervisor.supervisor_should_run() is False
+
+
+def test_ensure_dev_keys_idempotent(monkeypatch, tmp_path):
+    """Same keys returned across two calls."""
+    monkeypatch.delenv('LIVEKIT_API_KEY', raising=False)
+    monkeypatch.delenv('LIVEKIT_API_SECRET', raising=False)
+    monkeypatch.setenv('HEVOLVE_HOME', str(tmp_path))
+    from integrations.social import livekit_supervisor
+    a = livekit_supervisor.ensure_dev_keys()
+    b = livekit_supervisor.ensure_dev_keys()
+    assert a['api_key'] == b['api_key']
+    assert a['api_secret'] == b['api_secret']
+    assert a['api_key'].startswith('API')
+    assert len(a['api_secret']) >= 32
+
+
+def test_ensure_dev_keys_env_override_wins(monkeypatch, tmp_path):
+    """Env-var keys take priority — no dev_keys.json written."""
+    monkeypatch.setenv('LIVEKIT_API_KEY', 'OPERATOR_KEY')
+    monkeypatch.setenv('LIVEKIT_API_SECRET', 'OPERATOR_SECRET')
+    monkeypatch.setenv('HEVOLVE_HOME', str(tmp_path))
+    from integrations.social import livekit_supervisor
+    keys = livekit_supervisor.ensure_dev_keys()
+    assert keys['api_key'] == 'OPERATOR_KEY'
+    assert keys['api_secret'] == 'OPERATOR_SECRET'
+    # No file written — env path bypasses persistence.
+    assert not (tmp_path / 'livekit' / 'dev_keys.json').exists()

--- a/tests/unit/test_agent_engine.py
+++ b/tests/unit/test_agent_engine.py
@@ -413,7 +413,7 @@ class TestAgentDaemon:
         assert daemon._running is True
         daemon.stop()
 
-    @patch('integrations.coding_agent.idle_detection.IdleDetectionService.get_idle_opted_in_agents')
+    @patch('integrations.coding_agent.idle_detection.IdleDetectionService.get_idle_agent_personas')
     def test_daemon_tick_dispatches(self, mock_idle, db, test_user, test_product):
         from integrations.agent_engine.agent_daemon import AgentDaemon
 

--- a/tests/unit/test_chat_messages_external.py
+++ b/tests/unit/test_chat_messages_external.py
@@ -1,0 +1,176 @@
+"""Unit tests for ``chat_messages.persist_external_room_event`` (UNIF-G3).
+
+Pure shape tests — no DB, no adapter, no live transport.  Verifies that
+the helper produces the canonical field mapping documented in its
+docstring so adapters can rely on it for chronological cross-channel
+recall.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+
+class PersistExternalRoomEventTest(unittest.TestCase):
+
+    def setUp(self):
+        from integrations.social import chat_messages as cm
+        self.cm = cm
+
+    def _capture_call(self, *args, **kwargs):
+        # Capture every persist_and_publish_async invocation so the
+        # tests can assert on its kwargs without hitting the DB.
+        self.captured.append((args, kwargs))
+
+    def test_canonical_shape_for_text_message(self):
+        self.captured = []
+        with patch.object(self.cm, 'persist_and_publish_async',
+                          side_effect=self._capture_call):
+            self.cm.persist_external_room_event(
+                user_id='owner-1',
+                platform='discord',
+                room_id='channel-42',
+                sender_id='alice',
+                text='hello from discord',
+                timestamp=1234567890.0,
+                lang='en',
+                msg_id='msg-1',
+            )
+        self.assertEqual(len(self.captured), 1)
+        args, kwargs = self.captured[0]
+        # Positional: user_id, role, content
+        self.assertEqual(args[0], 'owner-1')
+        self.assertEqual(args[1], 'user')   # auto-derived (sender != agent:*)
+        self.assertEqual(args[2], 'hello from discord')
+        # Composite channel_type encodes BOTH platform + room
+        self.assertEqual(kwargs['channel_type'], 'discord:channel-42')
+        # request_id groups by room
+        self.assertEqual(kwargs['request_id'], 'channel-42')
+        # device_id tells consumer this is adapter-side
+        self.assertEqual(kwargs['device_id'], 'adapter:discord')
+        # Provenance attachment
+        att = kwargs['attachments'][0]
+        self.assertEqual(att['kind'], 'external_room_msg')
+        self.assertEqual(att['platform'], 'discord')
+        self.assertEqual(att['room_id'], 'channel-42')
+        self.assertEqual(att['author'], 'alice')
+        self.assertEqual(att['t'], 1234567890.0)
+
+    def test_role_assistant_when_sender_is_agent(self):
+        self.captured = []
+        with patch.object(self.cm, 'persist_and_publish_async',
+                          side_effect=self._capture_call):
+            self.cm.persist_external_room_event(
+                user_id='owner-1',
+                platform='slack',
+                room_id='C123',
+                sender_id='agent:nunba-co-pilot',
+                text='here is the summary',
+            )
+        args, kwargs = self.captured[0]
+        self.assertEqual(args[1], 'assistant')
+
+    def test_role_explicit_overrides_heuristic(self):
+        self.captured = []
+        with patch.object(self.cm, 'persist_and_publish_async',
+                          side_effect=self._capture_call):
+            self.cm.persist_external_room_event(
+                user_id='owner-1',
+                platform='matrix',
+                room_id='!room:matrix.org',
+                sender_id='someone',
+                text='thinking…',
+                role='system',
+            )
+        args, _ = self.captured[0]
+        self.assertEqual(args[1], 'system')
+
+    def test_transcript_segment_kind_carries_extra(self):
+        self.captured = []
+        with patch.object(self.cm, 'persist_and_publish_async',
+                          side_effect=self._capture_call):
+            self.cm.persist_external_room_event(
+                user_id='owner-1',
+                platform='discord',
+                room_id='voice-room-7',
+                sender_id='alice',
+                text='hello there',
+                kind='transcript_segment',
+                extra={'t0': 12.5, 't1': 13.8, 'speaker': 'alice'},
+            )
+        _, kwargs = self.captured[0]
+        att = kwargs['attachments'][0]
+        self.assertEqual(att['kind'], 'transcript_segment')
+        self.assertEqual(att['t0'], 12.5)
+        self.assertEqual(att['t1'], 13.8)
+        self.assertEqual(att['speaker'], 'alice')
+        # Author is still preserved
+        self.assertEqual(att['author'], 'alice')
+
+    def test_extra_does_not_overwrite_canonical_fields(self):
+        # extra must NEVER clobber kind/platform/room_id/author —
+        # those come from named args.
+        self.captured = []
+        with patch.object(self.cm, 'persist_and_publish_async',
+                          side_effect=self._capture_call):
+            self.cm.persist_external_room_event(
+                user_id='owner-1',
+                platform='discord',
+                room_id='room-1',
+                sender_id='alice',
+                text='hi',
+                extra={'platform': 'WRONG', 'kind': 'WRONG',
+                       'room_id': 'WRONG', 'author': 'WRONG'},
+            )
+        _, kwargs = self.captured[0]
+        att = kwargs['attachments'][0]
+        self.assertEqual(att['platform'], 'discord')
+        self.assertEqual(att['kind'], 'external_room_msg')
+        self.assertEqual(att['room_id'], 'room-1')
+        self.assertEqual(att['author'], 'alice')
+
+    def test_missing_required_fields_no_op(self):
+        # Empty text / missing room / missing platform → silent no-op
+        # (no exception, no persist call).
+        self.captured = []
+        with patch.object(self.cm, 'persist_and_publish_async',
+                          side_effect=self._capture_call):
+            self.cm.persist_external_room_event(
+                user_id='', platform='x', room_id='y',
+                sender_id='z', text='nothing')
+            self.cm.persist_external_room_event(
+                user_id='u', platform='', room_id='y',
+                sender_id='z', text='nothing')
+            self.cm.persist_external_room_event(
+                user_id='u', platform='x', room_id='',
+                sender_id='z', text='nothing')
+            self.cm.persist_external_room_event(
+                user_id='u', platform='x', room_id='y',
+                sender_id='z', text='')
+        self.assertEqual(len(self.captured), 0)
+
+    def test_chronological_recall_orderable(self):
+        # When multiple events from different platforms come in, the
+        # attachment 't' field + content carry enough info that a
+        # downstream recall can sort them chronologically.  This test
+        # verifies the helper doesn't lose the timestamp.
+        self.captured = []
+        with patch.object(self.cm, 'persist_and_publish_async',
+                          side_effect=self._capture_call):
+            self.cm.persist_external_room_event(
+                user_id='u', platform='whatsapp', room_id='g1',
+                sender_id='a', text='one', timestamp=1000.0)
+            self.cm.persist_external_room_event(
+                user_id='u', platform='discord', room_id='c1',
+                sender_id='b', text='two', timestamp=2000.0)
+            self.cm.persist_external_room_event(
+                user_id='u', platform='telegram', room_id='t1',
+                sender_id='c', text='three', timestamp=3000.0)
+        timestamps = [c[1]['attachments'][0].get('t') for c in self.captured]
+        self.assertEqual(timestamps, [1000.0, 2000.0, 3000.0])
+        platforms = [c[1]['attachments'][0]['platform'] for c in self.captured]
+        self.assertEqual(platforms, ['whatsapp', 'discord', 'telegram'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_compute_optimizer.py
+++ b/tests/unit/test_compute_optimizer.py
@@ -940,5 +940,191 @@ class TestHistoryBounded(unittest.TestCase):
         self.assertEqual(opt._history.maxlen, 200)
 
 
+# ═══════════════════════════════════════════════════════════════════════
+# Monitor unification: get_latest_snapshot + collector split (2026-05-01)
+#
+# These tests lock down the four invariants that the monitor-parallel-path
+# consolidation depends on.  If any of these regress, ResourceGovernor
+# would either lose data (read None when optimizer is up) or trigger the
+# expensive process_iter walk on every Governor tick (5s) under sustained
+# pressure — undoing the GIL-stall fix.
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestGetLatestSnapshot(unittest.TestCase):
+    """Unification accessor for cross-module readers (esp. ResourceGovernor)."""
+
+    @staticmethod
+    def _mock_psutil(ram_percent=62.0):
+        """Build a deterministic psutil mock used by the tests below.
+        Mirrors ``_make_mock_psutil`` shape elsewhere in this file but
+        parametrizes ram_percent so threshold-breach scenarios are
+        easy to construct."""
+        mock_psutil = MagicMock()
+        mock_psutil.cpu_percent = MagicMock(return_value=35.0)
+        mem = MagicMock(percent=ram_percent, used=10 * (1024 ** 3),
+                        total=16 * (1024 ** 3))
+        mock_psutil.virtual_memory = MagicMock(return_value=mem)
+        swap = MagicMock(percent=10.0, total=4 * (1024 ** 3))
+        mock_psutil.swap_memory = MagicMock(return_value=swap)
+        disk = MagicMock(percent=55.0)
+        mock_psutil.disk_usage = MagicMock(return_value=disk)
+        mock_psutil.disk_io_counters = MagicMock(
+            return_value=MagicMock(read_bytes=500 * (1024 ** 2),
+                                   write_bytes=200 * (1024 ** 2)))
+        mock_psutil.net_io_counters = MagicMock(
+            return_value=MagicMock(bytes_sent=100 * (1024 ** 2),
+                                   bytes_recv=300 * (1024 ** 2)))
+        mock_psutil.process_iter = MagicMock(return_value=[])
+        return mock_psutil
+
+    @patch('core.compute_optimizer._try_detect_gpu')
+    @patch('core.compute_optimizer._try_import_psutil')
+    def test_returns_cached_within_ttl(self, mock_import, mock_gpu):
+        """Second call inside max_age_s returns SAME snap instance —
+        no rebuild, no second psutil hit.  Hot-path correctness."""
+        mock_import.return_value = self._mock_psutil()
+        mock_gpu.return_value = {'cuda_available': False}
+        opt = ComputeOptimizer()
+        s1 = opt.get_latest_snapshot(max_age_s=10.0)
+        s2 = opt.get_latest_snapshot(max_age_s=10.0)
+        self.assertIs(s1, s2,
+                      "second call within TTL must return the same instance")
+
+    @patch('core.compute_optimizer._try_detect_gpu')
+    @patch('core.compute_optimizer._try_import_psutil')
+    def test_refreshes_when_max_age_zero(self, mock_import, mock_gpu):
+        """max_age_s=0 forces a fresh snap — escape hatch for callers
+        that need a guaranteed-current read."""
+        mock_import.return_value = self._mock_psutil()
+        mock_gpu.return_value = {'cuda_available': False}
+        opt = ComputeOptimizer()
+        s1 = opt.get_latest_snapshot(max_age_s=10.0)
+        time.sleep(0.01)  # ensure timestamp delta is observable
+        s2 = opt.get_latest_snapshot(max_age_s=0.0)
+        self.assertIsNot(s1, s2, "max_age=0 must produce a new snap")
+        self.assertGreater(s2.timestamp, s1.timestamp,
+                           "fresh snap must have a later timestamp")
+
+    @patch('core.compute_optimizer._try_detect_gpu')
+    @patch('core.compute_optimizer._try_import_psutil')
+    def test_skip_per_process_default_under_breach(self, mock_import, mock_gpu):
+        """CRITICAL regression guard.  When ram > RAM_HIGH_THRESHOLD,
+        ``snapshot()`` triggers the per-process walk — but
+        ``get_latest_snapshot(include_per_process=False)`` (the
+        default for cross-module readers) MUST skip it, otherwise
+        ResourceGovernor's 5s polling would trigger the GIL-heavy
+        walk under sustained pressure (the exact bug this
+        consolidation is meant to prevent).
+        """
+        ps = self._mock_psutil(ram_percent=90.0)  # well over RAM_HIGH=85
+        mock_import.return_value = ps
+        mock_gpu.return_value = {'cuda_available': False}
+        opt = ComputeOptimizer()
+        snap = opt.get_latest_snapshot(max_age_s=0.0,
+                                       include_per_process=False)
+        self.assertGreater(snap.ram_percent, 85,
+                           "test fixture must reproduce a breach")
+        self.assertEqual(snap.top_processes, [],
+                         "include_per_process=False MUST skip the walk "
+                         "even when threshold breached")
+        self.assertEqual(ps.process_iter.call_count, 0,
+                         "process_iter must not be invoked when caller "
+                         "passes include_per_process=False")
+
+    @patch('core.compute_optimizer._try_detect_gpu')
+    @patch('core.compute_optimizer._try_import_psutil')
+    def test_include_per_process_runs_walk_when_breached(
+            self, mock_import, mock_gpu):
+        """Inverse of the above — when caller explicitly requests
+        per-process AND threshold is breached, the walk runs.  Locks
+        in that the gate logic is preserved end-to-end."""
+        ps = self._mock_psutil(ram_percent=90.0)
+        mock_import.return_value = ps
+        mock_gpu.return_value = {'cuda_available': False}
+        opt = ComputeOptimizer()
+        opt.get_latest_snapshot(max_age_s=0.0, include_per_process=True)
+        self.assertGreaterEqual(
+            ps.process_iter.call_count, 1,
+            "process_iter must run when caller asks for per-process "
+            "AND threshold is breached")
+
+    @patch('core.compute_optimizer._try_detect_gpu')
+    @patch('core.compute_optimizer._try_import_psutil')
+    def test_snapshot_public_api_unchanged(self, mock_import, mock_gpu):
+        """The original ``snapshot()`` entry point is the contract
+        existing callers depend on (``_monitor_loop``, ``_emit_stats``,
+        the /optimizer/snapshot REST route, the test suite).  Refactor
+        must not change its behavior: full snap, _last_snapshot
+        updated, deque appended.
+        """
+        mock_import.return_value = self._mock_psutil()
+        mock_gpu.return_value = {'cuda_available': False}
+        opt = ComputeOptimizer()
+        snap = opt.snapshot()
+        self.assertIsNotNone(snap)
+        self.assertGreater(snap.timestamp, 0)
+        self.assertIs(opt._last_snapshot, snap,
+                      "snapshot() must update _last_snapshot")
+        self.assertEqual(len(opt._snapshots), 1,
+                         "snapshot() must append to history deque")
+
+
+class TestResourceGovernorReadsOptimizer(unittest.TestCase):
+    """ResourceGovernor consumes the optimizer's cached snapshot for
+    cpu/memory reads, with direct-psutil fallback when optimizer
+    isn't available (degraded boot or explicitly disabled deployment).
+    """
+
+    @patch('core.compute_optimizer._try_detect_gpu')
+    @patch('core.compute_optimizer._try_import_psutil')
+    def test_governor_uses_optimizer_when_available(
+            self, mock_import, mock_gpu):
+        """Happy path — optimizer is up, governor reads its snap."""
+        mock_psutil = MagicMock()
+        mock_psutil.cpu_percent = MagicMock(return_value=42.0)
+        mem = MagicMock(percent=63.0, used=10 * (1024 ** 3),
+                        total=16 * (1024 ** 3))
+        mock_psutil.virtual_memory = MagicMock(return_value=mem)
+        mock_psutil.swap_memory = MagicMock(
+            return_value=MagicMock(percent=5.0, total=4 * (1024 ** 3)))
+        mock_psutil.disk_usage = MagicMock(
+            return_value=MagicMock(percent=50.0))
+        mock_psutil.disk_io_counters = MagicMock(return_value=None)
+        mock_psutil.net_io_counters = MagicMock(return_value=None)
+        mock_psutil.process_iter = MagicMock(return_value=[])
+        mock_import.return_value = mock_psutil
+        mock_gpu.return_value = {'cuda_available': False}
+
+        # Prime the optimizer singleton with one fresh snap
+        from core.compute_optimizer import get_optimizer
+        get_optimizer().snapshot()
+
+        # Governor should now read those values via the cached snap
+        from core.resource_governor import ResourceGovernor
+        gov = ResourceGovernor.__new__(ResourceGovernor)
+        cpu = gov._get_cpu_usage()
+        mem_pressure = gov._get_memory_pressure()
+        self.assertAlmostEqual(cpu, 0.42, places=2,
+                               msg="governor should read cpu from snap (42%)")
+        self.assertAlmostEqual(mem_pressure, 0.63, places=2,
+                               msg="governor should read mem from snap (63%)")
+
+    def test_governor_falls_back_when_optimizer_import_fails(self):
+        """If ``get_optimizer`` raises (no optimizer in this build,
+        or singleton not initialized), governor must NOT crash —
+        falls back to direct psutil call.  Returns a sane 0-1 value.
+        """
+        from core.resource_governor import ResourceGovernor
+        gov = ResourceGovernor.__new__(ResourceGovernor)
+        with patch.object(gov, '_get_optimizer_snapshot',
+                          return_value=None):
+            cpu = gov._get_cpu_usage()
+            mem = gov._get_memory_pressure()
+        self.assertGreaterEqual(cpu, 0.0)
+        self.assertLessEqual(cpu, 1.0)
+        self.assertGreaterEqual(mem, 0.0)
+        self.assertLessEqual(mem, 1.0)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_discord_room_capable.py
+++ b/tests/unit/test_discord_room_capable.py
@@ -1,0 +1,302 @@
+"""Unit tests for Discord adapter ``RoomCapableAdapter`` implementation
+(UNIF-G2 / W1.1).
+
+discord.py is not in the standard CI install set, so these tests inject
+a faked ``discord`` module via ``sys.modules`` before importing
+``discord_adapter``.  The faked module exposes only the symbols
+``DiscordAdapter`` actually touches: ``Intents``, ``Embed``, ``File``,
+``Message``, ``DMChannel``, ``VoiceChannel``, ``LoginFailure``,
+``Forbidden``, ``HTTPException``, ``NotFound``, ``ClientException``,
+``opus.OpusNotLoaded``, ``ext.commands.Bot``, ``ui.View``, ``ui.Button``,
+``ButtonStyle.link``, ``ButtonStyle.primary``.
+
+The tests cover:
+  - ``is_room_capable`` returns True for a DiscordAdapter
+  - ``join_room`` text channel → True + recorded in ``_joined_text_rooms``
+  - ``join_room`` voice channel → calls ``connect`` + caches client
+  - ``join_room`` voice idempotent (no double-connect)
+  - ``join_room`` DM → raises ``UnsupportedRoomError``
+  - ``join_room`` channel not found → False
+  - ``leave_room`` voice → disconnects + drops client
+  - ``leave_room`` text → discards from set
+  - ``leave_room`` unknown → False
+  - ``list_room_members`` skips the bot itself + returns id/display_name
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _install_fake_discord():
+    """Build and register a faked ``discord`` module tree just rich
+    enough for ``discord_adapter`` to import + instantiate.
+    """
+    if 'discord' in sys.modules:
+        return  # already faked / installed
+
+    discord_mod = types.ModuleType('discord')
+
+    class Intents:
+        @staticmethod
+        def default():
+            inst = Intents()
+            inst.message_content = False
+            inst.members = False
+            inst.dm_messages = False
+            inst.guild_messages = False
+            inst.voice_states = False
+            return inst
+
+    class _BaseError(Exception):
+        pass
+
+    class Forbidden(_BaseError):
+        pass
+
+    class NotFound(_BaseError):
+        pass
+
+    class ClientException(_BaseError):
+        pass
+
+    class LoginFailure(_BaseError):
+        pass
+
+    class HTTPException(_BaseError):
+        def __init__(self, *args, status=None, retry_after=None, **kwargs):
+            super().__init__(*args)
+            self.status = status
+            self.retry_after = retry_after
+
+    class _ChannelMarker:
+        """Base marker for channel kinds; tests subclass to attach data."""
+        pass
+
+    class DMChannel(_ChannelMarker):
+        pass
+
+    class VoiceChannel(_ChannelMarker):
+        pass
+
+    class TextChannel(_ChannelMarker):
+        pass
+
+    discord_mod.Intents = Intents
+    discord_mod.Forbidden = Forbidden
+    discord_mod.NotFound = NotFound
+    discord_mod.ClientException = ClientException
+    discord_mod.LoginFailure = LoginFailure
+    discord_mod.HTTPException = HTTPException
+    discord_mod.DMChannel = DMChannel
+    discord_mod.VoiceChannel = VoiceChannel
+    discord_mod.TextChannel = TextChannel
+    discord_mod.Embed = type('Embed', (), {'__init__': lambda self, **kw: None})
+    discord_mod.File = type('File', (), {'__init__': lambda self, *a, **kw: None})
+    discord_mod.Message = type('Message', (), {})
+    discord_mod.ButtonStyle = types.SimpleNamespace(link='link', primary='primary')
+
+    opus_mod = types.ModuleType('discord.opus')
+    class OpusNotLoaded(_BaseError):
+        pass
+    opus_mod.OpusNotLoaded = OpusNotLoaded
+    discord_mod.opus = opus_mod
+
+    ui_mod = types.ModuleType('discord.ui')
+    ui_mod.View = type('View', (), {
+        '__init__': lambda self: setattr(self, '_items', []),
+        'add_item': lambda self, item: self._items.append(item),
+    })
+    ui_mod.Button = type('Button', (), {'__init__': lambda self, **kw: None})
+    discord_mod.ui = ui_mod
+
+    ext_mod = types.ModuleType('discord.ext')
+    commands_mod = types.ModuleType('discord.ext.commands')
+
+    class Bot:
+        def __init__(self, command_prefix='!', intents=None, **kwargs):
+            self.command_prefix = command_prefix
+            self.intents = intents
+            self.user = MagicMock(id=999, name='HiveAgentBot',
+                                  discriminator='0001')
+            self._channels = {}
+            # event registration is a no-op for tests
+            self.event = lambda fn: fn
+
+        def get_channel(self, cid):
+            return self._channels.get(cid)
+
+        async def fetch_channel(self, cid):
+            ch = self._channels.get(cid)
+            if ch is None:
+                raise NotFound("not found")
+            return ch
+
+        async def close(self):
+            pass
+
+        async def start(self, token):
+            pass
+
+    commands_mod.Bot = Bot
+    ext_mod.commands = commands_mod
+
+    sys.modules['discord'] = discord_mod
+    sys.modules['discord.opus'] = opus_mod
+    sys.modules['discord.ui'] = ui_mod
+    sys.modules['discord.ext'] = ext_mod
+    sys.modules['discord.ext.commands'] = commands_mod
+
+
+# Install BEFORE import of discord_adapter
+_install_fake_discord()
+
+from integrations.channels.base import ChannelConfig  # noqa: E402
+from integrations.channels.discord_adapter import (  # noqa: E402
+    DiscordAdapter,
+)
+from integrations.channels.room_capable import (  # noqa: E402
+    UnsupportedRoomError, is_room_capable,
+)
+
+
+def _make_adapter(channels: dict | None = None) -> DiscordAdapter:
+    """Build a DiscordAdapter with a fake bot whose channel registry
+    is the supplied dict (id -> channel-like object).
+    """
+    cfg = ChannelConfig(token='fake-token')
+    a = DiscordAdapter(cfg)
+    a._bot_user_id = 999  # match the fake Bot.user.id
+    if channels:
+        a._bot._channels = channels
+    return a
+
+
+class DiscordRoomCapableTest(unittest.TestCase):
+
+    def test_adapter_is_room_capable(self):
+        a = _make_adapter()
+        self.assertTrue(is_room_capable(a))
+
+    def test_join_text_channel_caches_presence(self):
+        import discord
+        ch = discord.TextChannel()
+        ch.id = 100
+        ch.members = []
+        a = _make_adapter({100: ch})
+        ok = asyncio.run(a.join_room('100', 'co_pilot'))
+        self.assertTrue(ok)
+        self.assertIn(100, a._joined_text_rooms)
+        self.assertNotIn(100, a._voice_clients)
+
+    def test_join_voice_channel_connects(self):
+        import discord
+        vc = discord.VoiceChannel()
+        vc.id = 200
+        client_mock = MagicMock()
+        client_mock.is_connected.return_value = True
+        client_mock.disconnect = AsyncMock()
+        vc.connect = AsyncMock(return_value=client_mock)
+        a = _make_adapter({200: vc})
+        ok = asyncio.run(a.join_room('200', 'note_taker'))
+        self.assertTrue(ok)
+        self.assertIn(200, a._voice_clients)
+        vc.connect.assert_awaited_once()
+
+    def test_join_voice_idempotent(self):
+        import discord
+        vc = discord.VoiceChannel()
+        vc.id = 200
+        client_mock = MagicMock()
+        client_mock.is_connected.return_value = True
+        vc.connect = AsyncMock(return_value=client_mock)
+        a = _make_adapter({200: vc})
+
+        ok1 = asyncio.run(a.join_room('200'))
+        ok2 = asyncio.run(a.join_room('200'))
+        self.assertTrue(ok1)
+        self.assertTrue(ok2)
+        # connect should be called exactly once across two joins
+        self.assertEqual(vc.connect.await_count, 1)
+
+    def test_join_dm_raises_unsupported(self):
+        import discord
+        dm = discord.DMChannel()
+        dm.id = 300
+        a = _make_adapter({300: dm})
+        with self.assertRaises(UnsupportedRoomError):
+            asyncio.run(a.join_room('300'))
+
+    def test_join_unknown_returns_false(self):
+        a = _make_adapter({})  # no channels registered
+        ok = asyncio.run(a.join_room('404'))
+        self.assertFalse(ok)
+
+    def test_leave_voice_disconnects(self):
+        import discord
+        vc = discord.VoiceChannel()
+        vc.id = 200
+        client_mock = MagicMock()
+        client_mock.is_connected.return_value = True
+        client_mock.disconnect = AsyncMock()
+        vc.connect = AsyncMock(return_value=client_mock)
+        a = _make_adapter({200: vc})
+
+        asyncio.run(a.join_room('200'))
+        self.assertIn(200, a._voice_clients)
+        ok = asyncio.run(a.leave_room('200'))
+        self.assertTrue(ok)
+        self.assertNotIn(200, a._voice_clients)
+        client_mock.disconnect.assert_awaited_once()
+
+    def test_leave_text_clears_presence(self):
+        import discord
+        ch = discord.TextChannel()
+        ch.id = 100
+        ch.members = []
+        a = _make_adapter({100: ch})
+        asyncio.run(a.join_room('100'))
+        self.assertIn(100, a._joined_text_rooms)
+        ok = asyncio.run(a.leave_room('100'))
+        self.assertTrue(ok)
+        self.assertNotIn(100, a._joined_text_rooms)
+
+    def test_leave_unknown_returns_false(self):
+        a = _make_adapter({})
+        ok = asyncio.run(a.leave_room('999'))
+        self.assertFalse(ok)
+
+    def test_list_members_skips_bot(self):
+        import discord
+        bot_member = MagicMock(id=999, display_name='HiveBot', name='HiveBot',
+                               bot=True)
+        alice = MagicMock(id=1, display_name='Alice', name='alice', bot=False)
+        bobbot = MagicMock(id=2, display_name='Bobbot', name='bobbot',
+                           bot=True)
+        ch = discord.TextChannel()
+        ch.id = 100
+        ch.members = [bot_member, alice, bobbot]
+        a = _make_adapter({100: ch})
+        members = asyncio.run(a.list_room_members('100'))
+        ids = [m['id'] for m in members]
+        self.assertNotIn('999', ids)  # bot itself filtered
+        self.assertIn('1', ids)
+        self.assertIn('2', ids)
+        # display_name + is_bot present
+        alice_dict = next(m for m in members if m['id'] == '1')
+        self.assertEqual(alice_dict['display_name'], 'Alice')
+        self.assertFalse(alice_dict['is_bot'])
+        bob_dict = next(m for m in members if m['id'] == '2')
+        self.assertTrue(bob_dict['is_bot'])
+
+    def test_list_members_unknown_returns_empty(self):
+        a = _make_adapter({})
+        result = asyncio.run(a.list_room_members('999'))
+        self.assertEqual(result, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_error_advice_goal_pickup.py
+++ b/tests/unit/test_error_advice_goal_pickup.py
@@ -158,3 +158,66 @@ def test_error_advice_emits_self_heal_with_correct_keys():
     assert 'install failed: missing transitive' in (
         config.get('error_message') or ''
     )
+
+
+def test_remediation_failure_logged_at_warning_not_debug(caplog):
+    """When _try_agent_remediation can't create the goal (db_session
+    import fails, GoalManager raises, etc.), the failure must surface
+    at WARNING level — not DEBUG.
+
+    Previously logger.debug hid this, so an open self-heal loop
+    (goals never created, agent never invoked) was invisible at
+    production log levels.  This test pins the new behavior.
+    """
+    import logging
+    from core import error_advice as ea
+
+    # Force the inner import in _try_agent_remediation to raise so we
+    # exercise the except branch.
+    fake_gm_module = MagicMock()
+
+    def _raises(*a, **kw):
+        raise RuntimeError("simulated GoalManager failure")
+
+    fake_gm_module.GoalManager.create_goal = _raises
+
+    fake_session = MagicMock()
+    fake_session.__enter__ = MagicMock(return_value=fake_session)
+    fake_session.__exit__ = MagicMock(return_value=False)
+    fake_models_module = MagicMock()
+    fake_models_module.db_session = MagicMock(return_value=fake_session)
+
+    with patch.dict(sys.modules, {
+        'integrations.agent_engine.goal_manager': fake_gm_module,
+        'integrations.social.models': fake_models_module,
+    }):
+        ea._THROTTLE.clear()
+        with caplog.at_level(logging.WARNING, logger='hevolve_error_advice'):
+            try:
+                raise RuntimeError("the original failure")
+            except RuntimeError as e:
+                ea.handle_exception(
+                    e,
+                    category='tts.install',
+                    severity='high',
+                    agent_remediation=True,
+                    context={'backend': 'chatterbox_turbo'},
+                )
+
+    # Must have one WARNING record describing the goal creation failure
+    warnings = [r for r in caplog.records
+                if r.levelname == 'WARNING'
+                and 'agent remediation goal creation failed' in r.message]
+    assert warnings, (
+        f"Expected a WARNING log line about goal creation failure. "
+        f"Got records: {[(r.levelname, r.message) for r in caplog.records]}"
+    )
+    msg = warnings[0].message
+    # Must include the category for log-grep filtering
+    assert '[error_advice/tts.install]' in msg, (
+        f"WARNING must include the [error_advice/<category>] tag: {msg!r}"
+    )
+    # Must include the exception TYPE, not just str(exc), for triage
+    assert 'RuntimeError' in msg, (
+        f"WARNING must name the inner exception type: {msg!r}"
+    )

--- a/tests/unit/test_install_links_deeplink.py
+++ b/tests/unit/test_install_links_deeplink.py
@@ -1,0 +1,117 @@
+"""Unit tests for ``core.install_links`` deep-link helpers (UNIF-G4).
+
+Verifies the custom-scheme validator + URL builders.  Pure shape /
+contract — no DB, no network.
+"""
+from __future__ import annotations
+
+import unittest
+
+
+class IsAllowedDeeplinkUriTest(unittest.TestCase):
+
+    def test_accepts_canonical_invite_uri(self):
+        from core.install_links import is_allowed_deeplink_uri
+        self.assertTrue(is_allowed_deeplink_uri('hevolveai://invite/abc123'))
+        self.assertTrue(is_allowed_deeplink_uri('nunba://invite/abc123'))
+
+    def test_accepts_meet_with_platform_and_room(self):
+        from core.install_links import is_allowed_deeplink_uri
+        self.assertTrue(is_allowed_deeplink_uri(
+            'hevolveai://meet/discord/voice-room-7'))
+        self.assertTrue(is_allowed_deeplink_uri(
+            'nunba://meet/teams/abc-def-ghi'))
+
+    def test_accepts_group_with_platform_and_id(self):
+        from core.install_links import is_allowed_deeplink_uri
+        self.assertTrue(is_allowed_deeplink_uri(
+            'hevolveai://group/whatsapp/120363145'))
+
+    def test_rejects_https_scheme(self):
+        # HTTPS URIs go through is_allowed_install_link, NOT this helper.
+        from core.install_links import is_allowed_deeplink_uri
+        self.assertFalse(is_allowed_deeplink_uri(
+            'https://hevolve.ai/invite/abc'))
+
+    def test_rejects_unknown_scheme(self):
+        from core.install_links import is_allowed_deeplink_uri
+        self.assertFalse(is_allowed_deeplink_uri(
+            'evil://invite/abc'))
+        self.assertFalse(is_allowed_deeplink_uri(
+            'javascript://invite/abc'))
+
+    def test_rejects_unknown_verb(self):
+        from core.install_links import is_allowed_deeplink_uri
+        self.assertFalse(is_allowed_deeplink_uri(
+            'hevolveai://login/abc'))
+        self.assertFalse(is_allowed_deeplink_uri(
+            'nunba://exec/rm-rf'))
+
+    def test_rejects_missing_trailing_segment(self):
+        from core.install_links import is_allowed_deeplink_uri
+        self.assertFalse(is_allowed_deeplink_uri('hevolveai://invite'))
+        self.assertFalse(is_allowed_deeplink_uri('hevolveai://invite/'))
+        # meet needs platform + room — only platform isn't enough
+        self.assertFalse(is_allowed_deeplink_uri('hevolveai://meet/discord'))
+
+    def test_rejects_empty_or_garbage(self):
+        from core.install_links import is_allowed_deeplink_uri
+        self.assertFalse(is_allowed_deeplink_uri(''))
+        self.assertFalse(is_allowed_deeplink_uri(None))
+        self.assertFalse(is_allowed_deeplink_uri(123))
+
+
+class BuilderHelpersTest(unittest.TestCase):
+
+    def test_invite_link_default_scheme(self):
+        from core.install_links import invite_link
+        self.assertEqual(invite_link('abc123'),
+                         'hevolveai://invite/abc123')
+
+    def test_invite_link_nunba_scheme(self):
+        from core.install_links import invite_link
+        self.assertEqual(invite_link('abc', scheme='nunba'),
+                         'nunba://invite/abc')
+
+    def test_invite_link_rejects_empty_code(self):
+        from core.install_links import invite_link
+        with self.assertRaises(ValueError):
+            invite_link('')
+
+    def test_invite_link_rejects_unknown_scheme(self):
+        from core.install_links import invite_link
+        with self.assertRaises(ValueError):
+            invite_link('abc', scheme='evil')
+
+    def test_meet_link(self):
+        from core.install_links import meet_link
+        self.assertEqual(meet_link('Discord', 'room-7'),
+                         'hevolveai://meet/discord/room-7')
+        # Platform name lowercased
+        self.assertEqual(meet_link('TEAMS', 'abc'),
+                         'hevolveai://meet/teams/abc')
+
+    def test_meet_link_rejects_missing_args(self):
+        from core.install_links import meet_link
+        with self.assertRaises(ValueError):
+            meet_link('', 'room-7')
+        with self.assertRaises(ValueError):
+            meet_link('discord', '')
+
+    def test_group_link(self):
+        from core.install_links import group_link
+        self.assertEqual(group_link('whatsapp', '120363'),
+                         'hevolveai://group/whatsapp/120363')
+
+    def test_round_trip_builder_validator(self):
+        # Anything we build must pass our own allowlist.
+        from core.install_links import (
+            group_link, invite_link, is_allowed_deeplink_uri, meet_link,
+        )
+        self.assertTrue(is_allowed_deeplink_uri(invite_link('x')))
+        self.assertTrue(is_allowed_deeplink_uri(meet_link('discord', 'r1')))
+        self.assertTrue(is_allowed_deeplink_uri(group_link('slack', 'C1')))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_liquid_ui_meet_copilot.py
+++ b/tests/unit/test_liquid_ui_meet_copilot.py
@@ -1,0 +1,79 @@
+"""Unit tests for the ``meet_copilot`` LiquidUI component type (UNIF-G5).
+
+Verifies the new component-type allowlist entry accepts the documented
+schema and the surrounding agent_ui_update path doesn't reject it.
+Pure schema test — no transport, no frontend.
+"""
+from __future__ import annotations
+
+import unittest
+
+
+class MeetCopilotComponentTypeTest(unittest.TestCase):
+
+    def test_meet_copilot_in_component_types(self):
+        from integrations.agent_engine.liquid_ui_service import (
+            COMPONENT_TYPES,
+        )
+        self.assertIn('meet_copilot', COMPONENT_TYPES)
+
+    def test_meet_copilot_props_documented(self):
+        # Props enumerated in the schema must cover everything the
+        # MeetCopilotOverlay frontend renderer reads.
+        from integrations.agent_engine.liquid_ui_service import (
+            COMPONENT_TYPES,
+        )
+        props = set(COMPONENT_TYPES['meet_copilot']['props'])
+        # Header
+        self.assertIn('platform', props)
+        self.assertIn('room_id', props)
+        self.assertIn('state', props)
+        self.assertIn('agent_role', props)
+        # Body
+        self.assertIn('transcript_lines', props)
+        self.assertIn('decisions', props)
+        self.assertIn('action_items', props)
+        self.assertIn('participants', props)
+        # Footer (leave action targets call_id)
+        self.assertIn('call_id', props)
+
+    def test_agent_ui_update_accepts_meet_copilot(self):
+        # The agent_ui_update validator at line 363 rejects unknown
+        # component types; this guards against accidental removal.
+        from integrations.agent_engine.liquid_ui_service import (
+            LiquidUIService,
+        )
+        svc = LiquidUIService()
+        result = svc.agent_ui_update('meet_copilot_call_42', {
+            'type': 'meet_copilot',
+            'call_id': 'call_42',
+            'platform': 'discord',
+            'room_id': 'voice-room-7',
+            'state': 'live',
+            'transcript_lines': [
+                {'speaker': 'alice', 'text': 'hello'},
+                {'speaker': 'bob', 'text': 'hi there'},
+            ],
+            'decisions': ['use postgres'],
+            'action_items': [{'text': 'sathish writes the migration'}],
+            'participants': ['alice', 'bob', 'agent:nunba'],
+            'agent_role': 'note_taker',
+        })
+        self.assertTrue(result)
+
+    def test_agent_ui_update_rejects_typo(self):
+        from integrations.agent_engine.liquid_ui_service import (
+            LiquidUIService,
+        )
+        svc = LiquidUIService()
+        # Typo ('meet_copliot') must be rejected
+        result = svc.agent_ui_update('x', {
+            'type': 'meet_copliot',
+            'call_id': 'c',
+            'platform': 'discord',
+        })
+        self.assertFalse(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_model_orchestrator_stale_cache.py
+++ b/tests/unit/test_model_orchestrator_stale_cache.py
@@ -1,0 +1,231 @@
+"""Regression for task #80 — stale-cache reconciliation in
+ModelOrchestrator.load().
+
+Background: On 2026-05-04 the user observed Nunba spinning with
+"Draft boot decision: ... → single (main-only)" every 30s for
+14 minutes after llama-server died externally (CUDA crash).  Root
+cause: orchestrator.load() short-circuited at "if entry.loaded:
+return entry" without probing the actual subprocess.  ensure_loaded_async
+returned "Model already loaded" forever, the supervisor never
+respawned.
+
+Fix: load() now calls loader.is_loaded(entry) — the live probe
+override — when the cache says loaded.  If the probe says dead,
+release VRAM, mark unloaded in catalog, fall through to a fresh
+load.  Loaders without an override fall back to entry.loaded
+(base class default), preserving prior behavior.
+
+This test pins both halves of the contract.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+
+def _make_orchestrator_with_loader(probe_returns: bool):
+    """Build an orchestrator with a fake catalog + loader where
+    is_loaded() returns the configured value.  Returns
+    (orch, fake_loader, fake_entry, fake_catalog) so each test can
+    assert on whichever side it cares about.
+    """
+    from integrations.service_tools.model_orchestrator import (
+        ModelOrchestrator, ModelLoader,
+    )
+
+    fake_entry = MagicMock()
+    fake_entry.id = 'llm-test-4b'
+    fake_entry.model_type = 'llm'
+    fake_entry.loaded = True              # cache says loaded
+    fake_entry.device = 'gpu'
+    fake_entry.vram_gb = 3.0
+    fake_entry.ram_gb = 0.0
+
+    fake_catalog = MagicMock()
+    fake_catalog.get.return_value = fake_entry
+    fake_catalog.mark_unloaded = MagicMock()
+    fake_catalog.mark_loaded = MagicMock()
+    fake_catalog.mark_error = MagicMock()
+    fake_catalog.list_types.return_value = []
+    fake_catalog.list_by_type.return_value = []
+
+    class _FakeLoader(ModelLoader):
+        def __init__(self):
+            self.is_loaded_calls = 0
+            self.load_calls = 0
+
+        def is_loaded(self, entry):
+            self.is_loaded_calls += 1
+            return probe_returns
+
+        def load(self, entry, run_mode):
+            self.load_calls += 1
+            return True
+
+        def is_downloaded(self, entry):
+            return True
+
+        def download(self, entry):
+            return True
+
+    orch = ModelOrchestrator(catalog=fake_catalog)
+    fake_loader = _FakeLoader()
+    orch.register_loader('llm', fake_loader)
+    return orch, fake_loader, fake_entry, fake_catalog
+
+
+def test_load_returns_early_when_probe_confirms_loaded():
+    """Cache says loaded AND probe says alive → return entry without
+    re-running compute checks or _dispatch_load."""
+    orch, loader, entry, catalog = _make_orchestrator_with_loader(
+        probe_returns=True
+    )
+    result = orch.load('llm-test-4b')
+    assert result is entry, "Expected to return the cached entry"
+    assert loader.is_loaded_calls == 1, "is_loaded probe must be invoked"
+    assert loader.load_calls == 0, "Should NOT re-dispatch load"
+    assert catalog.mark_unloaded.call_count == 0, (
+        "Catalog must NOT be marked unloaded — process is alive"
+    )
+
+
+def test_load_reconciles_stale_cache_when_probe_says_dead(caplog):
+    """Cache says loaded BUT probe says dead → release VRAM,
+    mark_unloaded in catalog, fall through to a fresh _dispatch_load.
+    This is the exact failure mode that produced the 14-minute "Draft
+    boot decision" loop on 2026-05-04 (task #80)."""
+    orch, loader, entry, catalog = _make_orchestrator_with_loader(
+        probe_returns=False
+    )
+
+    # Stub out the compute-state lookup so _attempt_swap doesn't blow
+    # up looking for VRAMManager.  Returning gpu_available=True with
+    # adequate free VRAM means matches_compute returns 'gpu' → load
+    # path proceeds to _dispatch_load.
+    orch._get_compute_state = MagicMock(return_value={
+        'vram_free_gb': 8.0,
+        'ram_free_gb': 16.0,
+        'gpu_available': True,
+    })
+    entry.matches_compute = MagicMock(return_value='gpu')
+
+    # Stub _register_vram so the load path doesn't need a real
+    # VRAMManager.  Stub _release_vram so we can assert it was called
+    # during reconciliation.
+    orch._register_vram = MagicMock(return_value=True)
+    orch._release_vram = MagicMock()
+    orch._register_lifecycle = MagicMock()
+    orch._register_service_tool = MagicMock()
+
+    with caplog.at_level(logging.WARNING, logger='ModelOrchestrator'):
+        result = orch.load('llm-test-4b')
+
+    # Probe was invoked
+    assert loader.is_loaded_calls == 1, "is_loaded probe must be invoked"
+    # VRAM release happened during reconciliation (NOT just on
+    # eventual unload — the point is to free VRAM so the fresh load
+    # has room).
+    assert orch._release_vram.call_args_list, (
+        "VRAM must be released during stale-cache reconciliation"
+    )
+    # Catalog was marked unloaded so subsequent ensure_loaded_async
+    # callers don't see the stale flag.
+    assert catalog.mark_unloaded.call_args_list, (
+        "Catalog must be marked unloaded during reconciliation"
+    )
+    # The reconciliation warning surfaced (operator visibility).
+    stale_warnings = [
+        r for r in caplog.records
+        if r.levelname == 'WARNING' and 'Stale cache' in r.message
+    ]
+    assert stale_warnings, (
+        f"Expected a 'Stale cache' WARNING. Got: "
+        f"{[(r.levelname, r.message) for r in caplog.records]}"
+    )
+    # _dispatch_load was actually invoked — the fresh respawn happened.
+    assert loader.load_calls == 1, (
+        "Loader.load() must be invoked after stale-cache reconciliation "
+        "(fresh respawn) — this is the bug fix"
+    )
+    # The fresh load succeeded so we got an entry back.
+    assert result is entry
+
+
+def test_load_falls_back_to_cache_flag_when_probe_raises(caplog):
+    """If the loader's is_loaded() override itself raises, we trust
+    the cache flag (conservative — better to over-report alive than
+    spuriously evict a working model).  The probe failure must surface
+    at WARNING for operator visibility."""
+    from integrations.service_tools.model_orchestrator import (
+        ModelOrchestrator, ModelLoader,
+    )
+
+    fake_entry = MagicMock()
+    fake_entry.id = 'llm-test-4b'
+    fake_entry.model_type = 'llm'
+    fake_entry.loaded = True
+    fake_entry.device = 'gpu'
+
+    fake_catalog = MagicMock()
+    fake_catalog.get.return_value = fake_entry
+
+    class _RaisingLoader(ModelLoader):
+        def is_loaded(self, entry):
+            raise RuntimeError("simulated probe failure")
+
+    orch = ModelOrchestrator(catalog=fake_catalog)
+    orch.register_loader('llm', _RaisingLoader())
+
+    with caplog.at_level(logging.WARNING, logger='ModelOrchestrator'):
+        result = orch.load('llm-test-4b')
+
+    assert result is fake_entry, (
+        "Probe failure must NOT block the early-return — fall back to "
+        "trusting the cache flag"
+    )
+    # Operator should see WHY the probe failed
+    probe_warnings = [
+        r for r in caplog.records
+        if r.levelname == 'WARNING' and 'is_loaded probe failed' in r.message
+    ]
+    assert probe_warnings, (
+        "Probe failure must log at WARNING (not be silent) so an open "
+        "loader-bug isn't masked"
+    )
+
+
+def test_load_uses_default_is_loaded_when_loader_has_no_override():
+    """Loaders that don't override is_loaded() inherit the base class
+    default (return entry.loaded).  This preserves prior behavior for
+    every loader except LlamaLoader (which is the bug-fix case).
+    """
+    from integrations.service_tools.model_orchestrator import (
+        ModelOrchestrator, ModelLoader,
+    )
+
+    fake_entry = MagicMock()
+    fake_entry.id = 'tts-piper-cpu'
+    fake_entry.model_type = 'tts'
+    fake_entry.loaded = True
+    fake_entry.device = 'cpu'
+
+    fake_catalog = MagicMock()
+    fake_catalog.get.return_value = fake_entry
+
+    class _MinimalLoader(ModelLoader):
+        # No is_loaded override — uses base default
+        pass
+
+    orch = ModelOrchestrator(catalog=fake_catalog)
+    orch.register_loader('tts', _MinimalLoader())
+    result = orch.load('tts-piper-cpu')
+    # Base default returns entry.loaded → True → early-return
+    assert result is fake_entry

--- a/tests/unit/test_room_capable.py
+++ b/tests/unit/test_room_capable.py
@@ -1,0 +1,83 @@
+"""Unit tests for ``integrations.channels.room_capable`` (UNIF-G2 Mixin).
+
+Pure interface contract — no I/O, no network.  Tests cover:
+  - is_room_capable() correctly distinguishes Mixin'd vs non-Mixin'd adapters
+  - default RoomCapableAdapter raises NotImplementedError (forces subclasses
+    to implement)
+  - default list_room_members returns [] (so adapters that can't list
+    members don't have to override)
+  - UnsupportedRoomError is a proper Exception subclass
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+
+class IsRoomCapableTest(unittest.TestCase):
+
+    def test_plain_object_is_not_room_capable(self):
+        from integrations.channels.room_capable import is_room_capable
+        self.assertFalse(is_room_capable(object()))
+        self.assertFalse(is_room_capable(None))
+        self.assertFalse(is_room_capable("string-not-an-adapter"))
+
+    def test_mixin_subclass_is_room_capable(self):
+        from integrations.channels.room_capable import (
+            RoomCapableAdapter, is_room_capable,
+        )
+
+        class FakeRoomAdapter(RoomCapableAdapter):
+            pass
+
+        self.assertTrue(is_room_capable(FakeRoomAdapter()))
+
+
+class DefaultMixinTest(unittest.TestCase):
+
+    def test_join_room_default_raises_not_implemented(self):
+        from integrations.channels.room_capable import RoomCapableAdapter
+
+        class Bare(RoomCapableAdapter):
+            pass
+
+        with self.assertRaises(NotImplementedError):
+            asyncio.run(Bare().join_room('room-1'))
+
+    def test_leave_room_default_raises_not_implemented(self):
+        from integrations.channels.room_capable import RoomCapableAdapter
+
+        class Bare(RoomCapableAdapter):
+            pass
+
+        with self.assertRaises(NotImplementedError):
+            asyncio.run(Bare().leave_room('room-1'))
+
+    def test_list_room_members_default_returns_empty(self):
+        # list_room_members is optional — default empty list lets
+        # adapters without member-listing skip the override.
+        from integrations.channels.room_capable import RoomCapableAdapter
+
+        class Bare(RoomCapableAdapter):
+            pass
+
+        result = asyncio.run(Bare().list_room_members('room-1'))
+        self.assertEqual(result, [])
+
+
+class UnsupportedRoomErrorTest(unittest.TestCase):
+
+    def test_is_exception_subclass(self):
+        from integrations.channels.room_capable import UnsupportedRoomError
+        self.assertTrue(issubclass(UnsupportedRoomError, Exception))
+
+    def test_carries_message(self):
+        from integrations.channels.room_capable import UnsupportedRoomError
+        try:
+            raise UnsupportedRoomError("SMS does not support rooms")
+        except UnsupportedRoomError as e:
+            self.assertIn("SMS", str(e))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_room_presence_service.py
+++ b/tests/unit/test_room_presence_service.py
@@ -1,0 +1,177 @@
+"""Unit tests for ``integrations.social.room_presence_service`` (UNIF-G6).
+
+Per ``feedback_test_what_we_ship.md`` the new module ships with tests
+that exercise its pure helpers + audit hooks.  The interactive paths
+(real ChannelAdapter join, ConsentService DB) are exercised by the
+adapter-level tests in tests/integration/ later.
+
+Coverage targets here:
+  - ``is_objection`` — i18n phrase matcher, no side effects
+  - ``_scope_for_role`` — role → scope mapping (private but stable)
+  - ``gate`` — denies on missing consent, audit log fired
+  - ``announce_presence`` — uses adapter.send_message, audits success/fail
+  - ``listen_for_objection`` — registers handler; objection triggers detach
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class IsObjectionTest(unittest.TestCase):
+    """Pure-function matcher; no DB, no adapter."""
+
+    def setUp(self):
+        from integrations.social.room_presence_service import is_objection
+        self.is_objection = is_objection
+
+    def test_empty_or_none(self):
+        self.assertFalse(self.is_objection(''))
+        self.assertFalse(self.is_objection(None))
+
+    def test_unrelated_text(self):
+        self.assertFalse(self.is_objection('hello world'))
+        self.assertFalse(self.is_objection('let us discuss the project'))
+
+    def test_english_phrases(self):
+        for p in ('no AI', 'No Ai please', 'kick the bot',
+                  '/agent-out', 'remove ai now', 'no agent'):
+            with self.subTest(phrase=p):
+                self.assertTrue(self.is_objection(p))
+
+    def test_multilingual(self):
+        # Spot-check at least one phrase from several supported langs.
+        cases = [
+            'sin ia',          # es
+            "pas d'ia",        # fr
+            'keine ki',        # de
+            'sem ia',          # pt
+            'wu ai',           # zh transliteration
+            'ai venda',        # ta latin
+        ]
+        for phrase in cases:
+            with self.subTest(phrase=phrase):
+                self.assertTrue(self.is_objection(phrase))
+
+    def test_case_insensitive(self):
+        self.assertTrue(self.is_objection('NO AI'))
+        self.assertTrue(self.is_objection('No Ai'))
+
+
+class ScopeForRoleTest(unittest.TestCase):
+
+    def test_known_roles_map_to_distinct_scopes(self):
+        from integrations.social.room_presence_service import _scope_for_role
+        self.assertEqual(_scope_for_role('note_taker'),
+                         'agent_listens_external_audio')
+        self.assertEqual(_scope_for_role('writer'),
+                         'agent_writes_external_room')
+        self.assertEqual(_scope_for_role('co_pilot'),
+                         'agent_joins_external_room')
+        self.assertEqual(_scope_for_role('participant'),
+                         'agent_joins_external_room')
+
+    def test_unknown_role_falls_back(self):
+        from integrations.social.room_presence_service import _scope_for_role
+        # Unknown role → default scope, not an error
+        self.assertEqual(_scope_for_role('intergalactic_overlord'),
+                         'agent_joins_external_room')
+        self.assertEqual(_scope_for_role(''), 'agent_joins_external_room')
+
+
+class GateTest(unittest.TestCase):
+    """``gate`` is the consent decision point.  Fails-closed on errors."""
+
+    def test_consent_unavailable_fails_closed(self):
+        from integrations.social import room_presence_service as rps
+        # Force the import inside gate() to raise — sim DB outage.
+        with patch.dict('sys.modules',
+                        {'integrations.social.consent_service': None}):
+            allowed, reason = rps.gate('user-1', 'discord', 'room-1', 'co_pilot')
+        self.assertFalse(allowed)
+        self.assertIn('unavailable', reason.lower())
+
+    def test_grant_allows(self):
+        from integrations.social import room_presence_service as rps
+        with patch('integrations.social.consent_service.ConsentService.check_consent',
+                   return_value=True), \
+             patch('integrations.social.models.get_db') as mock_get_db, \
+             patch.object(rps, '_audit') as mock_audit:
+            mock_get_db.return_value = MagicMock()
+            allowed, reason = rps.gate('user-1', 'discord', 'room-1', 'co_pilot')
+        self.assertTrue(allowed)
+        self.assertEqual(reason, 'ok')
+        # Audit log was fired with action='allowed'
+        actions = [c.args[2] for c in mock_audit.call_args_list]
+        self.assertIn('allowed', actions)
+
+    def test_no_consent_denies_with_reason(self):
+        from integrations.social import room_presence_service as rps
+        with patch('integrations.social.consent_service.ConsentService.check_consent',
+                   return_value=False), \
+             patch('integrations.social.models.get_db') as mock_get_db, \
+             patch.object(rps, '_audit') as mock_audit:
+            mock_get_db.return_value = MagicMock()
+            allowed, reason = rps.gate('user-1', 'discord', 'room-1', 'note_taker')
+        self.assertFalse(allowed)
+        # The reason mentions the right scope so the UI prompt can
+        # surface it directly.
+        self.assertIn('agent_listens_external_audio', reason)
+        actions = [c.args[2] for c in mock_audit.call_args_list]
+        self.assertIn('denied_no_consent', actions)
+
+
+class AnnouncePresenceTest(unittest.TestCase):
+    """``announce_presence`` posts via adapter.send_message + audits."""
+
+    def _make_adapter(self, *, success=True):
+        adapter = MagicMock()
+        adapter.name = 'discord'
+        result = MagicMock()
+        result.success = success
+        result.message_id = 'msg-123'
+
+        async def _send(chat_id, text, **kwargs):
+            self.last_text = text
+            self.last_chat_id = chat_id
+            return result
+
+        adapter.send_message = _send
+        return adapter
+
+    def test_announce_posts_disclosure_text(self):
+        from integrations.social import room_presence_service as rps
+        adapter = self._make_adapter()
+        with patch.object(rps, '_audit') as mock_audit:
+            ok = rps.announce_presence(
+                adapter, 'room-1', 'user-1', 'co_pilot',
+                owner_display_name='Alice')
+        self.assertTrue(ok)
+        # Disclosure includes role + opt-out instructions.
+        self.assertIn('Alice', self.last_text)
+        self.assertIn('co-pilot', self.last_text)
+        self.assertIn('no AI', self.last_text)
+        # Audit fired with 'announced'.
+        actions = [c.args[2] for c in mock_audit.call_args_list]
+        self.assertIn('announced', actions)
+
+
+class ListenForObjectionTest(unittest.TestCase):
+
+    def test_handler_registered(self):
+        from integrations.social import room_presence_service as rps
+        adapter = MagicMock()
+        rps.listen_for_objection(adapter, 'room-1', 'user-1', 'agent-1')
+        self.assertTrue(adapter.on_message.called)
+
+    def test_no_op_when_adapter_has_no_on_message(self):
+        from integrations.social import room_presence_service as rps
+        # Adapter without on_message attribute — should not raise.
+        class NoHookAdapter:
+            pass
+        rps.listen_for_objection(NoHookAdapter(), 'room-1', 'user-1', 'agent-1')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Bake LiveKit infra into HARTOS install — no external account or env var needed for flat/regional deploys. Central stays sync-only.

- New `livekit_supervisor.py` (582 LOC): dev-key gen + binary lifecycle + subprocess manager (exponential backoff respawn). Idempotent `ensure_dev_keys()` persists to `~/.hevolve/livekit/dev_keys.json` (mode 0600). `ensure_binary()` resolves env override → `~/.hevolve` → `PATH` (Dockerfile pre-stage) → lazy GitHub download. No-op when `HEVOLVE_DEPLOY_MODE=central` or `LIVEKIT_DISABLE=1`.
- `_decide_media_mode()` mesh-first promotion: ≤4 active voice → `p2p_mesh` (PeerLink-signaled WebRTC); `is_agent` / `screen_share` / `mixed` / >threshold → `livekit`. `LIVEKIT_MESH_THRESHOLD` env-tunable.
- `Dockerfile` (regional/flat): Layer 4 pre-stages livekit-server v1.7.2 binary at `/usr/local/bin` for amd64/arm64. Exposes 6777 / 7880 / 7881.
- `Dockerfile.prod` (central): explicit `HEVOLVE_DEPLOY_MODE=central + LIVEKIT_DISABLE=1`.
- `hart-first-boot.sh`: Step 5b pre-stages binary on ISO first boot for non-edge / non-OBSERVER tier (lazy retry on demand if offline).

## Test plan
- [x] `pytest tests/test_phase7d_calls.py` → 44 passed (+14 new tests covering `_decide_media_mode` and supervisor branches)
- [x] `pytest tests/test_phase7c{3,4,5}*.py` → 83 passed (regression sweep)
- [ ] CI: GitHub Actions runs on this PR
- [ ] Live test every supervisor branch (#276)
- [ ] Empirical mesh-vs-SFU threshold benchmark (#276)

PeerLink + WebRTC mesh stay the primary fabric; LiveKit is fallback only. Architecture invariants preserved per `memory/open_tasks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)