### PR TITLE
build(deps): add imageio + imageio-ffmpeg for video assembly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,17 @@ dependencies = [
     # Image processing
     "Pillow>=9.5.0,<13.0.0",
     "opencv-python",
+    # Video assembly — imageio + the bundled-ffmpeg plugin.  Used by
+    # integrations/remote_desktop/frame_capture.py::record_to_video
+    # (demo/call capture, invoked from agent_engine/marketing_tools.py)
+    # and integrations/vision/ltx2_server.py (LTX2 video generation).
+    # The imports are guarded (graceful GIF fallback when absent), but
+    # listing them here makes the mp4/H.264 path work out-of-the-box on
+    # flat/regional/central topologies across Win/macOS/Linux.  imageio
+    # is pure-Python; imageio-ffmpeg ships a per-OS ffmpeg wheel pip
+    # auto-selects.  Compatible with the numpy<2 + Pillow pins above.
+    "imageio>=2.30.0,<3.0.0",
+    "imageio-ffmpeg>=0.5.0,<1.0.0",
 
     # Speech-to-text (ONNX runtime — no PyTorch needed, CPU-optimized)
     "sherpa-onnx>=1.11.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,8 @@ httpx==0.28.1
 huggingface-hub==0.15.1
 humanfriendly==10.0
 idna==3.4
+imageio==2.37.3
+imageio-ffmpeg==0.6.0
 importlib-metadata==6.7.0
 itsdangerous==2.1.2
 Jinja2==3.1.2


### PR DESCRIPTION
## Summary
Adds `imageio` + `imageio-ffmpeg` to HARTOS dependencies — in both `pyproject.toml` (ranges) and `requirements.txt` (pins) — so the video-assembly features work out of the box on every OS.

## What needs it
- `integrations/remote_desktop/frame_capture.py::record_to_video` — demo/call capture, invoked by `integrations/agent_engine/marketing_tools.py`
- `integrations/vision/ltx2_server.py` — LTX2 video generation (gpu_worker subprocess)

Both already **guard** the import (graceful GIF fallback when absent), so this never blocked startup — it makes the mp4/H.264 path actually produce video.

## Cross-OS
`imageio` is pure-Python; `imageio-ffmpeg` ships a per-OS ffmpeg wheel pip auto-selects (Win/macOS/Linux). Compatible with the existing `numpy<2` + `Pillow` pins.

## Testing
- Resolves cleanly against existing pins (no numpy/Pillow change)
- Verified end-to-end: drove `record_to_video` → real **H.264 mp4** (codec confirmed via the bundled ffmpeg)
- HART engine boots clean on `:6777` with the deps installed (`/status` 200, `/health` alive)

Pairs with the Nunba PR that bundles the same deps into `python-embed`.
