### PR TITLE
fix(macos): gate brain on torch + sherpa STT accept_waveform

### DIFF
--- a/integrations/agent_engine/hevolveai_supervisor.py
+++ b/integrations/agent_engine/hevolveai_supervisor.py
@@ -167,6 +167,9 @@ def supervisor_should_run() -> bool:
       * hevolveai is neither importable nor resolvable via a dev
         sibling repo -- spawning would crash-loop (see
         ``_hevolveai_available``).
+      * the child interpreter cannot import ``torch`` -- the brain's
+        other hard dependency; spawning would crash-loop identically
+        (see ``_child_can_import_torch``).
     """
     if os.environ.get('HEVOLVE_SKIP_HEVOLVEAI_SPAWN') == '1':
         return False
@@ -174,6 +177,8 @@ def supervisor_should_run() -> bool:
     if url and ('localhost' not in url) and ('127.0.0.1' not in url):
         return False
     if not _hevolveai_available():
+        return False
+    if not _child_can_import_torch():
         return False
     return True
 
@@ -232,6 +237,67 @@ def _resolve_hevolveai_pythonpath() -> Optional[str]:
     if (candidate / 'hevolveai').is_dir():
         return str(candidate)
     return None
+
+
+# Cached verdict of the child-interpreter torch probe (see below).
+# None = not yet probed; True/False = the cached result for this process.
+_CHILD_TORCH_OK: Optional[bool] = None
+
+
+def _child_can_import_torch() -> bool:
+    """True when the CHILD interpreter can resolve ``torch``.
+
+    The brain hard-requires torch: ``hevolveai.server.api_server`` imports
+    ``embodied_ai.monitoring.weight_tracker`` at module load, which does
+    ``import torch``.  Without it the child exits rc=1 in <1s and the
+    supervisor crash-loops -- the SAME failure ``_hevolveai_available``
+    guards against for the hevolveai package, but for torch.
+
+    Why probe the CHILD rather than a parent ``find_spec`` (as
+    ``_hevolveai_available`` does for hevolveai): the parent's torch is
+    NOT representative of the child on macOS/Linux.  There
+    ``_resolve_python_exe`` falls back to ``sys.executable`` -- the frozen
+    Nunba binary run as ``<exe> -c`` -- whose sys.path is the minimal
+    frozen ``library.zip`` + ``lib`` set; torch is not bundled there even
+    when the parent process resolved torch from a dev ``.venv``.  On
+    Windows the child is ``python-embed/python.exe``, which carries torch
+    in its site-packages, so the probe passes and the brain spawns
+    normally.  This is a POSITIVE capability gate, not an OS check: the
+    brain auto-enables on any box where the child can import torch.
+
+    One short, cached subprocess per process (``find_spec`` only -- does
+    not load torch).  Conservative: any probe failure / timeout ->
+    unavailable, so a flaky probe never starts a crash-looping child.
+    macOS incident 2026-06-16: the post-build ``Nunba --validate`` smoke
+    test spawned this brain, which crash-looped on ``import torch`` (torch
+    absent from the frozen ``-c`` child) ~20x and failed DMG packaging.
+    See tests/unit/test_supervisor_torch_gate.py.
+    """
+    global _CHILD_TORCH_OK
+    if _CHILD_TORCH_OK is not None:
+        return _CHILD_TORCH_OK
+    verdict = False
+    try:
+        from core.subprocess_safe import run_bounded
+        res = run_bounded(
+            [_resolve_python_exe(), '-c',
+             "import importlib.util as u, sys; "
+             "sys.exit(0 if u.find_spec('torch') else 3)"],
+            timeout=30.0,
+        )
+        verdict = (res.returncode == 0 and not res.timed_out)
+    except Exception as e:  # FileNotFoundError / OSError / anything
+        logger.warning(
+            "hevolveai_supervisor: torch probe failed (%s); treating torch "
+            "as unavailable and skipping brain spawn", e)
+        verdict = False
+    if not verdict:
+        logger.info(
+            "hevolveai_supervisor: child interpreter (%s) cannot import "
+            "torch; brain spawn disabled (install torch where the child "
+            "resolves it to enable embodied-AI)", _resolve_python_exe())
+    _CHILD_TORCH_OK = verdict
+    return verdict
 
 
 # Canonical armored-import snippet for the spawned hevolveai server.
@@ -812,6 +878,10 @@ def start_supervisor() -> Dict[str, Any]:
             _reason = ('hevolveai not installed/importable and no dev '
                        'sibling repo found -- supervisor disabled (set '
                        'HEVOLVEAI_HOME or pip install hevolveai to enable)')
+        elif not _child_can_import_torch():
+            _reason = ('child interpreter cannot import torch -- supervisor '
+                       'disabled to avoid a crash-loop (install torch where '
+                       'the child resolves it to enable embodied-AI)')
         else:
             _reason = 'remote HEVOLVEAI_API_URL -- supervisor not started'
         return {'should_run': False, 'reason': _reason}

--- a/integrations/service_tools/whisper_tool.py
+++ b/integrations/service_tools/whisper_tool.py
@@ -443,12 +443,48 @@ def _get_sherpa_recognizer(model_name: str = "whisper-tiny"):
     return _sherpa_recognizer
 
 
+def _read_wav_f32(audio_path: str):
+    """Read a PCM WAV into ``(sample_rate, float32 mono samples in [-1, 1])``.
+
+    sherpa-onnx's ``OfflineStream.accept_waveform`` wants normalized float32
+    samples + the source sample rate.  The realtime STT pipeline writes 16-bit
+    PCM WAV (see the streaming writer ~L1229).  Uses ONLY stdlib ``wave`` +
+    numpy — no libsndfile / ffmpeg native dependency — so it behaves
+    identically in the frozen bundle on Windows, macOS and Linux.
+    """
+    import wave
+    import numpy as np
+    with wave.open(audio_path, 'rb') as wf:
+        sample_rate = wf.getframerate()
+        n_channels = wf.getnchannels()
+        sampwidth = wf.getsampwidth()
+        raw = wf.readframes(wf.getnframes())
+    if sampwidth == 2:
+        data = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+    elif sampwidth == 4:
+        data = np.frombuffer(raw, dtype=np.int32).astype(np.float32) / 2147483648.0
+    elif sampwidth == 1:  # 8-bit PCM is unsigned, centred at 128
+        data = (np.frombuffer(raw, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
+    else:
+        raise ValueError(f"unsupported WAV sample width: {sampwidth} bytes")
+    if n_channels > 1:  # down-mix to mono
+        data = data.reshape(-1, n_channels).mean(axis=1)
+    return sample_rate, data
+
+
 def _sherpa_transcribe(audio_path: str, model_name: str) -> Optional[str]:
     """Transcribe using sherpa-onnx. Returns JSON string or None on failure."""
     try:
         recognizer = _get_sherpa_recognizer(model_name)
+        # sherpa-onnx OfflineStream has NO ``accept_wave_file`` (verified
+        # sherpa_onnx 1.13.1 — methods are accept_waveform/result/…); the
+        # canonical API is ``accept_waveform(sample_rate, float_samples)``.
+        # The old call raised AttributeError on every utterance, so STT
+        # returned empty text — mic captured, nothing transcribed/sent/shown
+        # (incident 2026-06-17).
+        sample_rate, samples = _read_wav_f32(audio_path)
         stream = recognizer.create_stream()
-        stream.accept_wave_file(audio_path)
+        stream.accept_waveform(sample_rate, samples)
         recognizer.decode_stream(stream)
         text = stream.result.text.strip()
 

--- a/tests/unit/test_supervisor_torch_gate.py
+++ b/tests/unit/test_supervisor_torch_gate.py
@@ -1,0 +1,112 @@
+"""The hevolveai brain spawn is gated on the CHILD interpreter importing torch.
+
+WHY (macOS incident 2026-06-16): the brain's api_server imports
+weight_tracker -> ``import torch`` at module load.  ``_hevolveai_available``
+only checked that *hevolveai* was importable in the parent, not torch.  On the
+frozen macOS build ``_resolve_python_exe`` falls back to ``sys.executable`` --
+the Nunba binary run as ``<exe> -c`` -- whose minimal frozen sys.path has no
+torch, so the brain crash-looped ~20x and failed the post-build ``--validate``
+DMG gate.
+
+The fix adds ``_child_can_import_torch``: a POSITIVE capability gate that probes
+the actual child interpreter once (cached) and is required by
+``supervisor_should_run``.  Windows (python-embed child carries torch) is
+unaffected -- the probe passes and the brain spawns normally.
+
+Behavioral: mock the ``run_bounded`` boundary + ``_hevolveai_available``; assert
+the gate.  Covers: probe pass/fail/timeout/spawn-error, caching, and the
+supervisor_should_run composition.
+"""
+import os
+import sys
+import types
+from unittest.mock import patch
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+import integrations.agent_engine.hevolveai_supervisor as sup  # noqa: E402
+
+
+def _bounded(returncode=0, timed_out=False):
+    """Stand-in for core.subprocess_safe.BoundedResult."""
+    return types.SimpleNamespace(
+        returncode=returncode, stdout='', stderr='', timed_out=timed_out)
+
+
+def _reset_cache():
+    sup._CHILD_TORCH_OK = None
+
+
+def _patch_probe(**bounded_kw):
+    """Patch run_bounded (imported lazily inside the probe) to return a
+    BoundedResult-like object, and reset the module cache first."""
+    _reset_cache()
+    return patch('core.subprocess_safe.run_bounded',
+                 return_value=_bounded(**bounded_kw))
+
+
+# ── _child_can_import_torch ──────────────────────────────────────────
+def test_torch_probe_true_when_child_resolves_torch():
+    with _patch_probe(returncode=0):
+        assert sup._child_can_import_torch() is True
+
+
+def test_torch_probe_false_when_child_missing_torch():
+    with _patch_probe(returncode=3):
+        assert sup._child_can_import_torch() is False
+
+
+def test_torch_probe_false_on_timeout():
+    # run_bounded returns returncode=-1, timed_out=True on timeout.
+    with _patch_probe(returncode=-1, timed_out=True):
+        assert sup._child_can_import_torch() is False
+
+
+def test_torch_probe_false_when_spawn_raises():
+    _reset_cache()
+    with patch('core.subprocess_safe.run_bounded',
+               side_effect=FileNotFoundError('no interpreter')):
+        assert sup._child_can_import_torch() is False
+
+
+def test_torch_probe_is_cached_one_spawn_per_process():
+    _reset_cache()
+    with patch('core.subprocess_safe.run_bounded',
+               return_value=_bounded(returncode=0)) as m:
+        assert sup._child_can_import_torch() is True
+        assert sup._child_can_import_torch() is True
+        assert m.call_count == 1  # second call hit the cache, no respawn
+
+
+# ── supervisor_should_run composition ────────────────────────────────
+def test_should_run_false_when_torch_absent_even_if_hevolveai_present():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop('HEVOLVE_SKIP_HEVOLVEAI_SPAWN', None)
+        os.environ.pop('HEVOLVEAI_API_URL', None)
+        with patch.object(sup, '_hevolveai_available', return_value=True), \
+                patch.object(sup, '_child_can_import_torch',
+                             return_value=False):
+            assert sup.supervisor_should_run() is False
+
+
+def test_should_run_true_when_hevolveai_and_torch_present():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop('HEVOLVE_SKIP_HEVOLVEAI_SPAWN', None)
+        os.environ.pop('HEVOLVEAI_API_URL', None)
+        with patch.object(sup, '_hevolveai_available', return_value=True), \
+                patch.object(sup, '_child_can_import_torch',
+                             return_value=True):
+            assert sup.supervisor_should_run() is True
+
+
+def test_should_run_skips_torch_probe_when_hevolveai_absent():
+    # Short-circuit order: never probe torch if hevolveai itself is missing.
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop('HEVOLVE_SKIP_HEVOLVEAI_SPAWN', None)
+        os.environ.pop('HEVOLVEAI_API_URL', None)
+        with patch.object(sup, '_hevolveai_available', return_value=False), \
+                patch.object(sup, '_child_can_import_torch') as probe:
+            assert sup.supervisor_should_run() is False
+            probe.assert_not_called()


### PR DESCRIPTION
Clean single-commit PR (off latest `main`, 0 behind, no merge commit). Cross-OS-positive — Windows path unchanged.

1. **hevolveai_supervisor**: skip the brain spawn when the child interpreter can't import torch. On the frozen macOS `.app` the child is the GUI binary (no python-embed, no torch) → it crash-looped on `import torch` and failed the post-build `--validate` DMG gate. New `_child_can_import_torch()` probes the child once (cached) — a positive **capability** gate, not an OS check (Windows' python-embed child has torch → brain spawns normally). Test: `tests/unit/test_supervisor_torch_gate.py` (8 pass).
2. **whisper_tool**: sherpa_onnx 1.13.1 `OfflineStream` has no `accept_wave_file` → every utterance threw → STT returned empty text (mic captured, nothing shown/sent). Switch to canonical `accept_waveform(sample_rate, float_samples)` via new `_read_wav_f32()` (stdlib `wave`+numpy, no native dep → cross-OS). Composes cleanly with the #131 VAD path already in main. Verified with real speech.