### PR TITLE
fix(auth): add HEVOLVE_DEV_NO_AUTH bypass for local channel testing

### DIFF
--- a/integrations/channels/telegram_adapter.py
+++ b/integrations/channels/telegram_adapter.py
@@ -154,7 +154,7 @@ class TelegramAdapter(ChannelAdapter, RoomCapableAdapter):
             self._handle_message
         ))
         self._app.add_handler(MessageHandler(
-            filters.PHOTO | filters.VIDEO | filters.DOCUMENT | filters.AUDIO | filters.VOICE,
+            filters.PHOTO | filters.VIDEO | filters.Document.ALL | filters.AUDIO | filters.VOICE,
             self._handle_media
         ))
 

--- a/integrations/channels/whatsapp/gateway.js
+++ b/integrations/channels/whatsapp/gateway.js
@@ -137,9 +137,59 @@ async function connectSocket(ctx) {
 
   sock.ev.on('messages.upsert', ({ messages }) => {
     for (const m of messages || []) {
-      broadcast(ctx, { type: 'message', message: m });
+      // Skip our own outgoing messages (incl. the bot's auto-replies) so
+      // an inbound → agent → reply never re-triggers itself into a loop.
+      if (m.key && m.key.fromMe) continue;
+      // The adapter (whatsapp_adapter.py:_convert_message) speaks the
+      // WAHA field shape (chat/sender/body/...), and _handle_event reads
+      // the `data` key.  Baileys emits a different raw shape, so map it
+      // here — this is the single seam that keeps the gateway
+      // "WAHA-compatible" as its package.json claims.
+      broadcast(ctx, { type: 'message', data: baileysToWaha(m) });
     }
   });
+}
+
+// Map a raw Baileys message object to the WAHA-style shape the Python
+// whatsapp_adapter expects.  Only the fields _convert_message reads.
+function baileysToWaha(m) {
+  const msg = (m && m.message) || {};
+  const remoteJid = (m.key && m.key.remoteJid) || '';
+  const isGroup = remoteJid.endsWith('@g.us');
+  const senderJid = (m.key && m.key.participant) || remoteJid || '';
+
+  let body = '';
+  if (msg.conversation) body = msg.conversation;
+  else if (msg.extendedTextMessage && msg.extendedTextMessage.text) {
+    body = msg.extendedTextMessage.text;
+  } else if (msg.imageMessage && msg.imageMessage.caption) {
+    body = msg.imageMessage.caption;
+  } else if (msg.videoMessage && msg.videoMessage.caption) {
+    body = msg.videoMessage.caption;
+  }
+
+  const mediaKeys = {
+    imageMessage: 'image', videoMessage: 'video', audioMessage: 'audio',
+    documentMessage: 'document', stickerMessage: 'sticker',
+  };
+  const mk = Object.keys(mediaKeys).find((k) => msg[k]);
+  const ctxInfo = (msg.extendedTextMessage && msg.extendedTextMessage.contextInfo) || {};
+
+  return {
+    id: { _serialized: (m.key && m.key.id) || '' },
+    chat: { id: { _serialized: remoteJid } },
+    sender: {
+      id: { _serialized: senderJid },
+      pushname: m.pushName || '',
+      name: m.pushName || '',
+    },
+    body,
+    isGroup,
+    hasMedia: !!mk,
+    type: mk ? mediaKeys[mk] : 'chat',
+    mentionedIds: ctxInfo.mentionedJid || [],
+    timestamp: m.messageTimestamp,
+  };
 }
 
 function broadcast(ctx, event) {
@@ -185,7 +235,13 @@ app.post('/api/sessions/:id/messages/send', async (req, res) => {
   if (!ctx || !ctx.authenticated) {
     return res.status(409).json({ error: 'not_authenticated' });
   }
-  const { to, text } = req.body || {};
+  // Accept both the WAHA-style `chatId` (what the Python adapter sends)
+  // and the plain `to` alias — otherwise the adapter's replies arrive
+  // with to=undefined and silently 400, so inbound routing works but no
+  // reply ever goes back out.
+  const body = req.body || {};
+  const to = body.to || body.chatId;
+  const text = body.text;
   if (!to || !text) {
     return res.status(400).json({ error: 'to + text required' });
   }

--- a/integrations/channels/whatsapp/gateway.js
+++ b/integrations/channels/whatsapp/gateway.js
@@ -42,7 +42,7 @@ const os = require('os');
 // at the bottom of the file BEFORE app.listen() — every handler that
 // references them runs only after a session is started, which can't
 // happen until the server is listening.
-let makeWASocket, useMultiFileAuthState;
+let makeWASocket, useMultiFileAuthState, DisconnectReason;
 
 let express, expressWs;
 try {
@@ -72,13 +72,8 @@ async function ensureSession(accountId) {
   let ctx = sessions.get(accountId);
   if (ctx) return ctx;
 
-  const authPath = path.join(AUTH_BASE, accountId);
-  fs.mkdirSync(authPath, { recursive: true });
-  const { state, saveCreds } = await useMultiFileAuthState(authPath);
-  const sock = makeWASocket({ auth: state, printQRInTerminal: false });
-
   ctx = {
-    sock,
+    sock: null,
     qr: null,
     authenticated: false,
     state: 'connecting',
@@ -86,6 +81,23 @@ async function ensureSession(accountId) {
     accountId,
   };
   sessions.set(accountId, ctx);
+
+  await connectSocket(ctx);
+  return ctx;
+}
+
+// Build (or rebuild) the Baileys socket for a session and wire its
+// event handlers.  Called on first start and again on any non-logged-out
+// disconnect — Baileys closes the stream with statusCode 515
+// (restartRequired) right after a successful QR/pair-code login and
+// expects the client to reconnect with the now-saved creds.  Without
+// this reconnect the session dies the instant pairing succeeds.
+async function connectSocket(ctx) {
+  const authPath = path.join(AUTH_BASE, ctx.accountId);
+  fs.mkdirSync(authPath, { recursive: true });
+  const { state, saveCreds } = await useMultiFileAuthState(authPath);
+  const sock = makeWASocket({ auth: state, printQRInTerminal: false });
+  ctx.sock = sock;
 
   sock.ev.on('creds.update', saveCreds);
 
@@ -103,9 +115,23 @@ async function ensureSession(accountId) {
     } else if (connection === 'close') {
       const code = lastDisconnect && lastDisconnect.error
         && lastDisconnect.error.output && lastDisconnect.error.output.statusCode;
-      ctx.authenticated = false;
-      ctx.state = 'disconnected';
-      broadcast(ctx, { type: 'disconnected', code });
+      const loggedOut = DisconnectReason && code === DisconnectReason.loggedOut;
+      if (!loggedOut) {
+        // restartRequired (515) after pairing, or any transient drop —
+        // reconnect with saved creds instead of leaving the session dead.
+        ctx.state = 'connecting';
+        broadcast(ctx, { type: 'reconnecting', code });
+        setTimeout(() => {
+          connectSocket(ctx).catch((e) => {
+            ctx.state = 'disconnected';
+            broadcast(ctx, { type: 'disconnected', code, error: String(e && e.message) });
+          });
+        }, 1000);
+      } else {
+        ctx.authenticated = false;
+        ctx.state = 'disconnected';
+        broadcast(ctx, { type: 'disconnected', code });
+      }
     }
   });
 
@@ -114,8 +140,6 @@ async function ensureSession(accountId) {
       broadcast(ctx, { type: 'message', message: m });
     }
   });
-
-  return ctx;
 }
 
 function broadcast(ctx, event) {
@@ -242,6 +266,7 @@ app.ws('/ws/:id', (ws, req) => {
     const baileys = await import('@whiskeysockets/baileys');
     makeWASocket = baileys.default || baileys.makeWASocket;
     useMultiFileAuthState = baileys.useMultiFileAuthState;
+    DisconnectReason = baileys.DisconnectReason;
   } catch (e) {
     console.error(JSON.stringify({
       event: 'startup_error',

--- a/integrations/social/auth.py
+++ b/integrations/social/auth.py
@@ -352,6 +352,33 @@ def require_auth(f):
     """
     @wraps(f)
     def decorated(*args, **kwargs):
+        # DEV bypass: skip auth entirely when HEVOLVE_DEV_NO_AUTH=true
+        if os.environ.get('HEVOLVE_DEV_NO_AUTH', '').lower() == 'true':
+            from .models import get_db, User
+            db = get_db()
+            user = db.query(User).first()
+            if not user:
+                user = User(id=1, username='dev', email='dev@local')
+                db.add(user)
+                db.flush()
+            g.user = user
+            g.user_id = str(user.id)
+            g.db = db
+            g.token_scope = 'dev'
+            g.token_node_id = ''
+            g.token_tenant_id = None
+            g.feature_flags = {}
+            try:
+                result = f(*args, **kwargs)
+                db.commit()
+                return result
+            except Exception:
+                if db.is_active:
+                    db.rollback()
+                raise
+            finally:
+                db.close()
+
         auth_header = request.headers.get('Authorization', '')
         # 2026-06-20: when Kong strips the upstream Authorization header
         # after its own pre-auth, HARTOS sees no Bearer but still gets


### PR DESCRIPTION
When HEVOLVE_DEV_NO_AUTH=true in .env, require_auth decorator auto-authenticates as first available user without JWT validation. Enables local channel binding testing without cloud token bridge.