### PR TITLE
fix(whatsapp): cap + back off gateway reconnects to avoid WhatsApp rate-limiting

### DIFF
--- a/integrations/channels/whatsapp/gateway.js
+++ b/integrations/channels/whatsapp/gateway.js
@@ -146,6 +146,7 @@ async function connectSocket(ctx) {
       ctx.authenticated = true;
       ctx.state = 'connected';
       ctx.qr = null;
+      ctx._reconnects = 0;  // healthy connection — reset the backoff counter
       broadcast(ctx, { type: 'authenticated' });
     } else if (connection === 'close') {
       // Intentional teardown (a newer request replaced this ctx with a
@@ -167,13 +168,44 @@ async function connectSocket(ctx) {
 
       const loggedOut = DisconnectReason && code === DisconnectReason.loggedOut;
       if (!loggedOut) {
-        connectSocket(ctx).catch((e) => {
+        // Backoff + cap so a repeatedly-rejected handshake cannot hot-loop
+        // connectSocket() and hammer WhatsApp into rate-limiting/blocking the
+        // number.  Previously this reconnected IMMEDIATELY with no delay and
+        // no limit, so a fresh-registration "Connection Failure" produced 60+
+        // attempts a minute and got the device temporarily blocked.
+        // restartRequired (515) right after pairing is the normal fast path
+        // and is not counted; every other close backs off exponentially and
+        // gives up after MAX_RECONNECTS consecutive failures (call /start
+        // again to retry a stopped session).
+        const MAX_RECONNECTS = 5;
+        const restartRequired = DisconnectReason
+          && code === DisconnectReason.restartRequired;
+        ctx._reconnects = restartRequired ? 0 : ((ctx._reconnects || 0) + 1);
+        if (ctx._reconnects > MAX_RECONNECTS) {
+          ctx.state = 'disconnected';
           console.error(JSON.stringify({
-            event: 'reconnect_failed',
+            event: 'reconnect_giveup',
             accountId: ctx.accountId,
-            error: String(e && e.message),
+            code,
+            attempts: ctx._reconnects,
+            detail: 'stopped reconnecting to avoid WhatsApp rate-limit; '
+              + 'POST /start again to retry',
           }));
-        });
+          broadcast(ctx, { type: 'disconnected', code, gaveUp: true });
+          return;
+        }
+        const delay = restartRequired
+          ? 1000
+          : Math.min(2000 * (2 ** (ctx._reconnects - 1)), 60000);
+        setTimeout(() => {
+          connectSocket(ctx).catch((e) => {
+            console.error(JSON.stringify({
+              event: 'reconnect_failed',
+              accountId: ctx.accountId,
+              error: String(e && e.message),
+            }));
+          });
+        }, delay);
       } else {
         // A real logout (the phone removed this linked device, or the
         // user unlinked it) — the socket is permanently dead and the


### PR DESCRIPTION
## What this does
Caps and backs off the WhatsApp (Baileys) gateway's reconnect loop so a repeatedly-rejected handshake can't get the device rate-limited/blocked by WhatsApp.

## The bug
On every non-logout `connection: 'close'`, the gateway called `connectSocket(ctx)` **immediately, with no delay and no limit**. A fresh-registration `"Connection Failure"` therefore hot-looped reconnects **60+ times a minute**, and WhatsApp temporarily **rate-limited / blocked the number** (observed live during pairing tests).

## The fix
- **Exponential backoff** between reconnects: `2s → 4s → 8s …` capped at `60s`.
- **Cap** consecutive failures at `MAX_RECONNECTS = 5`, then stop and emit a `reconnect_giveup` event (`POST /start` to retry) instead of looping forever.
- **`restartRequired` (code 515)** right after pairing is the normal fast path — reconnect in `1s` and **do not** count it toward the cap.
- **Reset** the counter to `0` on a healthy `'open'`, so a later blip starts fresh.

## Scope
- One file: `integrations/channels/whatsapp/gateway.js` (+36 / −4).
- **Only** the reconnect-backoff logic — deliberately excludes the separate `seenMessageIds` dedup work (not mine to land here).
- `node --check` passes.

## Testing
Reproduced the storm during live pairing (the 60+/min loop that got the test number blocked); with the cap+backoff the gateway stops after 5 tries and emits `reconnect_giveup` instead of hammering WhatsApp.
