### PR TITLE
fix(shell-auth): collapse 3 drifted auth decorators to one canonical (0.0.0.0 no longer trusted)

### DIFF
--- a/integrations/agent_engine/shell_auth.py
+++ b/integrations/agent_engine/shell_auth.py
@@ -1,0 +1,51 @@
+"""Canonical local-shell authentication — ONE implementation for every
+``shell_*`` API surface (os / system / desktop / installer).
+
+Historically each surface carried its own copy of this check and they DRIFTED:
+``shell_os_apis`` trusted ``0.0.0.0`` as a "local" origin, while
+``shell_system_apis`` and ``shell_desktop_apis`` (verbatim copies of each other)
+correctly did not. ``0.0.0.0`` is the "bind any interface" sentinel, never a real
+loopback *client* source address — trusting it let an unauthenticated request
+whose ``remote_addr`` reads ``0.0.0.0`` reach the os-shell routes with no token,
+a privilege-escalation gap the other two surfaces did not have.
+
+This module is the single source of truth so the surfaces can never drift again:
+``shell_os_apis._require_shell_auth``, ``shell_system_apis._require_system_auth``
+and ``shell_desktop_apis._require_desktop_auth`` all alias :func:`require_shell_auth`.
+"""
+import os
+from functools import wraps
+
+# Loopback origins that need no token. 0.0.0.0 is DELIBERATELY excluded: it is
+# the "bind any interface" sentinel, not a loopback client address, so a request
+# whose remote_addr is 0.0.0.0 is anomalous/spoofed and must present a token.
+LOCAL_ORIGINS = ('127.0.0.1', '::1', 'localhost')
+
+
+def shell_auth_ok():
+    """Return ``(ok, error_json, status)`` for the current Flask request.
+
+    Authorized when the request originates from a loopback origin OR carries a
+    valid ``X-Shell-Token`` header (set at desktop login). On success returns
+    ``(True, None, None)``; otherwise ``(False, <json>, 403)``.
+    """
+    from flask import request, jsonify
+    remote = request.remote_addr or ''
+    if remote in LOCAL_ORIGINS:
+        return True, None, None
+    token = request.headers.get('X-Shell-Token', '')
+    expected = os.environ.get('HART_SHELL_TOKEN', '')
+    if expected and token and token == expected:
+        return True, None, None
+    return False, jsonify({'error': 'Shell API: local access only'}), 403
+
+
+def require_shell_auth(f):
+    """Decorator enforcing :func:`shell_auth_ok` on a Flask view."""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        ok, err, status = shell_auth_ok()
+        if not ok:
+            return err, status
+        return f(*args, **kwargs)
+    return decorated

--- a/integrations/agent_engine/shell_desktop_apis.py
+++ b/integrations/agent_engine/shell_desktop_apis.py
@@ -423,20 +423,9 @@ _clipboard_counter = 0
 # Route registration
 # ═══════════════════════════════════════════════════════════════
 
-def _require_desktop_auth(f):
-    """Decorator: require local shell auth for destructive desktop ops."""
-    from functools import wraps
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        from flask import request, jsonify
-        remote = request.remote_addr or ''
-        if remote not in ('127.0.0.1', '::1', 'localhost'):
-            token = request.headers.get('X-Shell-Token', '')
-            expected = os.environ.get('HART_SHELL_TOKEN', '')
-            if not expected or token != expected:
-                return jsonify({'error': 'Unauthorized'}), 403
-        return f(*args, **kwargs)
-    return decorated
+# Canonical local-shell auth — the ONE shared implementation (was a per-file copy
+# of this decorator). See integrations.agent_engine.shell_auth.
+from integrations.agent_engine.shell_auth import require_shell_auth as _require_desktop_auth
 
 
 def _audit_desktop_op(action, detail=None):

--- a/integrations/agent_engine/shell_os_apis.py
+++ b/integrations/agent_engine/shell_os_apis.py
@@ -132,39 +132,20 @@ def _is_path_allowed(path, include_mounts=True):
 # ─── Shell Auth (local-only, no social DB dependency) ─────────────
 
 def _shell_auth_check():
-    """Verify request is from local desktop session.
+    """Canonical local-shell auth check — see ``integrations.agent_engine.shell_auth``.
 
-    Returns (ok, error_response) — if ok is True, request is authorized.
-    Accepts:
-      1. Localhost origin (127.0.0.1, ::1, 0.0.0.0) — desktop is local
-      2. Valid X-Shell-Token header (for remote LiquidUI sessions)
+    Kept as a thin, backward-compatible alias. Returns ``(ok, error_json, status)``:
+    ``(True, None, None)`` on success, else ``(False, <json>, 403)``.
     """
-    from flask import request, jsonify
-
-    remote = request.remote_addr or ''
-    local_addrs = ('127.0.0.1', '::1', '0.0.0.0', 'localhost')
-    if remote in local_addrs:
-        return True, None
-
-    # Check shell token (set during desktop login)
-    token = request.headers.get('X-Shell-Token', '')
-    if token:
-        expected = os.environ.get('HART_SHELL_TOKEN', '')
-        if expected and token == expected:
-            return True, None
-
-    return False, jsonify({'error': 'Shell API: local access only'}), 403
+    from integrations.agent_engine.shell_auth import shell_auth_ok
+    return shell_auth_ok()
 
 
-def _require_shell_auth(f):
-    """Decorator: require local shell authentication."""
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        result = _shell_auth_check()
-        if not result[0]:
-            return result[1], result[2]
-        return f(*args, **kwargs)
-    return decorated
+# This decorator used to be a per-file copy that trusted ``0.0.0.0`` as a local
+# origin, while shell_system_apis/shell_desktop_apis did NOT — a drifted parallel
+# path (privilege-escalation gap). It is now the ONE shared implementation, so the
+# surfaces can never diverge again.
+from integrations.agent_engine.shell_auth import require_shell_auth as _require_shell_auth
 
 
 # ─── Audit helper ──────────────────────────────────────────────────

--- a/integrations/agent_engine/shell_system_apis.py
+++ b/integrations/agent_engine/shell_system_apis.py
@@ -424,20 +424,9 @@ _media_lock = threading.Lock()
 # Route registration
 # ═══════════════════════════════════════════════════════════════
 
-def _require_system_auth(f):
-    """Decorator: require local shell auth for destructive system ops."""
-    from functools import wraps
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        from flask import request, jsonify
-        remote = request.remote_addr or ''
-        if remote not in ('127.0.0.1', '::1', 'localhost'):
-            token = request.headers.get('X-Shell-Token', '')
-            expected = os.environ.get('HART_SHELL_TOKEN', '')
-            if not expected or token != expected:
-                return jsonify({'error': 'Unauthorized'}), 403
-        return f(*args, **kwargs)
-    return decorated
+# Canonical local-shell auth — the ONE shared implementation (was a per-file copy
+# of this decorator). See integrations.agent_engine.shell_auth.
+from integrations.agent_engine.shell_auth import require_shell_auth as _require_system_auth
 
 
 def _audit_system_op(action, detail=None):

--- a/tests/unit/test_shell_auth_single_canonical.py
+++ b/tests/unit/test_shell_auth_single_canonical.py
@@ -1,0 +1,66 @@
+"""Parallel-path fix: the local-shell auth decorator was copied across
+shell_os_apis / shell_system_apis / shell_desktop_apis and DRIFTED —
+``shell_os_apis`` trusted ``0.0.0.0`` as a local origin while the other two did
+not, a privilege-escalation gap on the os-shell surface.
+
+These tests prove:
+  1. ``0.0.0.0`` is no longer trusted (the gap is closed).
+  2. A real loopback still needs no token; a valid ``X-Shell-Token`` still works.
+  3. All three surfaces now share the ONE canonical implementation (no drift).
+"""
+import os
+import pytest
+
+flask = pytest.importorskip("flask")
+
+from integrations.agent_engine.shell_auth import require_shell_auth
+
+
+def _call(remote_addr, headers=None):
+    app = flask.Flask(__name__)
+
+    @require_shell_auth
+    def view():
+        return "ok", 200
+
+    with app.test_request_context(
+        '/', environ_base={'REMOTE_ADDR': remote_addr}, headers=headers or {}
+    ):
+        return view()
+
+
+def _status(rv):
+    # allow → ("ok", 200); reject → (<json response>, 403)
+    return rv[1]
+
+
+def test_0000_is_not_trusted_as_local(monkeypatch):
+    monkeypatch.delenv('HART_SHELL_TOKEN', raising=False)
+    # remote 0.0.0.0, no token → must be REJECTED (was ALLOWED by shell_os_apis).
+    assert _status(_call('0.0.0.0')) == 403
+
+
+def test_loopback_allowed_without_token(monkeypatch):
+    monkeypatch.delenv('HART_SHELL_TOKEN', raising=False)
+    assert _call('127.0.0.1') == ("ok", 200)
+    assert _call('::1') == ("ok", 200)
+
+
+def test_token_gates_nonlocal_requests(monkeypatch):
+    monkeypatch.setenv('HART_SHELL_TOKEN', 'secret')
+    assert _call('10.0.0.5', headers={'X-Shell-Token': 'secret'}) == ("ok", 200)
+    assert _status(_call('10.0.0.5', headers={'X-Shell-Token': 'wrong'})) == 403
+    assert _status(_call('10.0.0.5')) == 403  # no token
+
+
+def test_all_three_surfaces_share_one_canonical_decorator():
+    """The whole point of the fix: no more parallel paths."""
+    from integrations.agent_engine import shell_auth
+    from integrations.agent_engine import shell_os_apis
+    from integrations.agent_engine import shell_system_apis
+    from integrations.agent_engine import shell_desktop_apis
+
+    canonical = shell_auth.require_shell_auth
+    assert shell_os_apis._require_shell_auth is canonical
+    assert shell_system_apis._require_system_auth is canonical
+    assert shell_desktop_apis._require_desktop_auth is canonical


### PR DESCRIPTION
## Parallel-path fix #3 (from `HARTOS_PARALLEL_PATH_AUDIT.md`): shell-auth decorator dedup

### The drift (security)
The local-shell auth decorator was **copied across three files and diverged**:
- `shell_os_apis._require_shell_auth` trusted **`0.0.0.0`** as a local origin (no token required)
- `shell_system_apis._require_system_auth` and `shell_desktop_apis._require_desktop_auth` (verbatim copies of each other) correctly did **not**

`0.0.0.0` is the "bind any interface" sentinel, never a real loopback *client* source address — so a request whose `remote_addr` reads `0.0.0.0` could reach the **os-shell routes unauthenticated**: a privilege-escalation gap on that surface only. `app_installer` already imported the os-shell copy, so it inherited the gap.

### The fix
- New **`integrations/agent_engine/shell_auth.py`** — ONE canonical `shell_auth_ok()` + `require_shell_auth` decorator, with the **safe** allowlist (`127.0.0.1`, `::1`, `localhost` — `0.0.0.0` deliberately excluded).
- `shell_os_apis` / `_system` / `_desktop` decorators now **alias** the canonical one; `_shell_auth_check` delegates to it. The surfaces can no longer drift.
- `+135 / −59` across 5 files (3 copies removed, 1 canonical added, 1 test added).

### Demo (ran locally, passing)
```
remote=0.0.0.0  no token   -> 403   ← gap closed (was 200 on os-shell)
remote=127.0.0.1 no token  -> 200   ← loopback still allowed
remote=10.0.0.5 valid tok  -> 200 ; wrong tok -> 403 ; no tok -> 403
shell_os/_system/_desktop all `is` the one canonical decorator: True / True / True
```
Covered by `tests/unit/test_shell_auth_single_canonical.py`.

### Self-review (findings checked & resolved pre-commit)
1. **Return-contract change** — old `_shell_auth_check` returned a 2-tuple on success; the canonical returns a uniform 3-tuple. Verified (grep) the **only** caller was the local decorator → safe; kept `_shell_auth_check` as a delegating alias for any out-of-tree caller.
2. **No import cycle** — `shell_auth` imports only `flask`/`os`/`functools` (nothing from the shell modules), so the shell modules importing it cannot cycle.
3. **`0.0.0.0` removal is safe, not a regression** — legit local traffic comes from `127.0.0.1`; `system`/`desktop` already excluded `0.0.0.0` and work, so this aligns `os_apis` with existing-safe behavior rather than changing the intended contract.
4. **All call sites preserved** — kept the decorator *names* as module aliases, so every `@_require_*` usage and cross-module import (`media_semantic_index`, `os_bridge/routes`, `app_installer`'s import + local fallback) still resolves; the identity test imports all three heavy modules cleanly.
5. **Error body unified** — `system`/`desktop` previously returned `{'error':'Unauthorized'}`; now `{'error':'Shell API: local access only'}`. Status stays **403**; only the text unifies — intentional, and no code asserts on the old string.
