### PR TITLE
fix(security): authenticate the power/session route (was unauthenticated)

### DIFF
--- a/integrations/agent_engine/liquid_ui_service.py
+++ b/integrations/agent_engine/liquid_ui_service.py
@@ -7076,7 +7076,15 @@ function renderAgentOverlay(ev) {{
                 return jsonify({'error': str(e)}), 500
 
         # ── Shell APIs: Session ──
+        # Auth gate — this power/session route (lock/logout/suspend/shutdown/
+        # restart/firmware) was UNAUTHENTICATED while its sibling
+        # /api/shell/power/action carried @_require_shell_auth, a drifted power
+        # surface that let any reachable caller power off the box. Both surfaces
+        # now share the ONE canonical local-shell gate.
+        from integrations.agent_engine.shell_os_apis import _require_shell_auth
+
         @app.route('/api/shell/session/<action>', methods=['POST'])
+        @_require_shell_auth
         def shell_session(action):
             # #133 — NATIVE logind power actions, result-checked. The shell server
             # runs as the unprivileged `hart` service user; the old fire-and-forget

--- a/tests/unit/test_power_session_route_authed.py
+++ b/tests/unit/test_power_session_route_authed.py
@@ -1,0 +1,42 @@
+"""Parallel-path fix #9: ``/api/shell/session/<action>`` (lock / logout / suspend
+/ shutdown / restart / firmware) was **UNAUTHENTICATED**, while its sibling
+``/api/shell/power/action`` carried ``@_require_shell_auth`` — a drifted power
+surface that let any reachable caller power off the box. Both power surfaces now
+share the ONE canonical local-shell gate.
+
+Tests:
+  1. the gate the route now uses rejects a non-local, tokenless request (403)
+  2. the ``shell_session`` route source is decorated with ``@_require_shell_auth``
+"""
+import re
+from pathlib import Path
+import pytest
+
+flask = pytest.importorskip("flask")
+
+from integrations.agent_engine.shell_os_apis import _require_shell_auth
+
+
+def test_gate_rejects_nonlocal_tokenless_request(monkeypatch):
+    monkeypatch.delenv('HART_SHELL_TOKEN', raising=False)
+    app = flask.Flask(__name__)
+
+    @_require_shell_auth
+    def view():
+        return "ok", 200
+
+    with app.test_request_context('/', environ_base={'REMOTE_ADDR': '10.0.0.9'}):
+        rv = view()
+    assert rv[1] == 403  # a power action is refused without local origin / token
+
+
+def test_session_route_is_decorated_with_auth():
+    src = (Path(__file__).resolve().parents[2]
+           / 'integrations' / 'agent_engine' / 'liquid_ui_service.py')
+    text = src.read_text(encoding='utf-8')
+    m = re.search(
+        r"@app\.route\('/api/shell/session/<action>'.*?\n\s*(@[\w_]+)\s*\n\s*def shell_session",
+        text, re.DOTALL)
+    assert m is not None, "session route + its decorator not found"
+    assert '_require_shell_auth' in m.group(1), \
+        "the power/session route is NOT gated by _require_shell_auth"


### PR DESCRIPTION
## Parallel-path fix #9 (`HARTOS_PARALLEL_PATH_AUDIT.md`): authenticate the power/session route

### The gap (security)
`/api/shell/session/<action>` (lock / logout / suspend / **shutdown** / **restart** / **firmware**) had **no auth decorator and no inline check**, while its sibling `/api/shell/power/action` carried `@_require_shell_auth`. A drifted power surface: any caller that could reach the shell server could power off / reboot / enter firmware with **no local-origin or token check**.

### The fix
- Gate the route with the **same `@_require_shell_auth`** the sibling uses — both power surfaces now share the one canonical local-shell gate.
- Imported at the enclosing scope right before the route (matches how the route already imports its `shell_os_apis` helpers locally).

### Demo (passed) + test
```
remote=10.0.0.9 (non-local, no token) -> 403   ← power action refused (was: executed)
remote=127.0.0.1 (local shell UI)     -> 200   ← still allowed
source: session route now decorated with @_require_shell_auth (was: none)
```
`tests/unit/test_power_session_route_authed.py`.

### Self-review (checked & resolved)
1. **Decorator order** — `@app.route` above `@_require_shell_auth` wraps auth first then registers the gated view; `@wraps` keeps `__name__='shell_session'` so the endpoint name is unchanged.
2. **Doesn't break the shell UI** — it calls from `127.0.0.1` → passes tokenless (same as the already-authed sibling). Verified loopback → 200.
3. **Forward-compatible with the shell-auth dedup PR** — imports `_require_shell_auth` from `shell_os_apis`; once that lands, this inherits the `0.0.0.0`-safe canonical gate.
4. **Scope** — closes the auth gap (critical part); the method map is already unified (`_POWER_METHOD`/`_logind_call`), so verb/adapter cosmetic dedup is a non-security follow-up, out of scope here.
