### PR TITLE
fix(parallel-paths): the 3 fixes not yet on main — canonical trust-contract signing, redactor gap, consent side-effect parity

### DIFF
--- a/integrations/social/consent_api.py
+++ b/integrations/social/consent_api.py
@@ -211,6 +211,22 @@ def revoke_consent():
     row.revoked_at = now
     g.db.flush()
 
+    # Parallel-path parity (audit #4): this UI surface keeps its OWN append-only
+    # row model on purpose — granted stays True and revoked_at is the tombstone
+    # (see the module docstring), which is deliberately NOT the same as
+    # ConsentService.revoke_consent's granted=False + agent_id-keyed row model,
+    # so we do not delegate the WRITE (that would corrupt the append-only audit
+    # trail). But the observable SIDE EFFECTS must not drift between the two
+    # writers, so fire them through the service's PUBLIC announce_revocation —
+    # the same entry point ConsentService.revoke_consent uses — rather than
+    # reaching into its underscore-private _audit/_emit. Previously a UI revoke
+    # left no audit entry and never reached WAMP/SSE listeners or the user's
+    # other devices. announce_revocation is best-effort (never raises), so this
+    # cannot fail the revoke.
+    from .consent_service import ConsentService
+    ConsentService.announce_revocation(
+        uid, consent_type, scope, getattr(row, 'agent_id', None))
+
     logger.info(
         'consent.revoke user=%s type=%s scope=%s id=%s',
         uid, consent_type, scope, row.id,

--- a/integrations/social/consent_service.py
+++ b/integrations/social/consent_service.py
@@ -313,6 +313,20 @@ class ConsentService:
         consent.revoked_at = datetime.utcnow()
         db.flush()
 
+        ConsentService.announce_revocation(user_id, consent_type, scope, agent_id)
+        return consent
+
+    @staticmethod
+    def announce_revocation(user_id: str, consent_type: str,
+                            scope: str = '*', agent_id=None):
+        """Fire the immutable-audit entry + ``consent.revoked`` broadcast for a
+        revocation. PUBLIC on purpose: a surface that revokes by its own row
+        model (the append-only ``consent_api`` UI path cannot delegate the WRITE
+        without corrupting its audit trail) still gets IDENTICAL observability by
+        calling this, instead of reaching into this module's underscore-private
+        ``_audit``/``_emit``. That keeps the grant/revoke side-effect parity
+        STRUCTURAL — a caller cannot get the row and silently skip the audit +
+        broadcast. Best-effort (never raises)."""
         _audit('consent', actor_id=user_id,
                action=f'consent.revoked:{consent_type}',
                detail={'scope': scope, 'agent_id': agent_id})
@@ -322,7 +336,6 @@ class ConsentService:
             'scope': scope,
             'agent_id': agent_id,
         })
-        return consent
 
     @staticmethod
     def check_consent(db, user_id: str, consent_type: str,

--- a/security/pre_trust_contract.py
+++ b/security/pre_trust_contract.py
@@ -133,7 +133,23 @@ class TrustContract:
 
 
 def _contract_payload(contract: TrustContract) -> str:
-    """Canonical payload for signing/verification (excludes signature itself)."""
+    """Canonical payload STRING for signing/verification (excludes signature itself).
+
+    Routes through the ONE canonical serialization
+    (``security.node_integrity.canonical_payload``) instead of re-implementing
+    ``json.dumps(sort_keys=True, separators=(',', ':'))`` inline. This was the 6th
+    inline copy of that serialization in the codebase; any drift between a signer's
+    copy and a verifier's copy silently breaks every trust-contract signature
+    network-wide. The seven fields below ARE exactly the signed set, so nothing is
+    stripped at serialization time (``exclude=()``) — the field selection stays
+    local and explicit, only the byte-level serialization is delegated.
+
+    Returns a ``str`` (the caller then ``.encode('utf-8')`` before signing) to
+    keep this helper's long-standing return type — callers and tests that already
+    do ``.encode('utf-8')`` are unaffected. ``canonical_payload`` emits UTF-8
+    bytes, so ``.decode('utf-8')`` here then ``.encode('utf-8')`` at the call site
+    is byte-identical to the old inline ``json.dumps``.
+    """
     payload = {
         'node_id': contract.node_id,
         'public_key_hex': contract.public_key_hex,
@@ -143,7 +159,8 @@ def _contract_payload(contract: TrustContract) -> str:
         'audit_compute_ratio': contract.audit_compute_ratio,
         'signed_at': contract.signed_at,
     }
-    return json.dumps(payload, sort_keys=True, separators=(',', ':'))
+    from security.node_integrity import canonical_payload
+    return canonical_payload(payload, exclude=()).decode('utf-8')
 
 
 def sign_trust_contract(

--- a/security/secret_redactor.py
+++ b/security/secret_redactor.py
@@ -94,16 +94,30 @@ _add('mailgun_key', r'\bkey-[A-Za-z0-9]{32}\b')
 # node_id / request_id / trace_id. Anchoring on the UUID shape ALONE redacted
 # every UUID in the logs and destroyed the "which node failed" diagnostic
 # (regression pinned by tests/unit/test_sync_failures_are_never_silent.py). A
-# UUID that is genuinely a secret (token=<uuid>, Authorization: <uuid>) is
-# already caught by `bearer_token` above, and identifier UUIDs are SHA-256'd in
-# Layer 2 — so here we anchor on a heroku context and leave a bare identifier
-# UUID visible.
+# UUID that is genuinely a secret is caught by context: `bearer_token` above
+# (token=/authorization=<uuid>) and `secret_assignment` above (api_key=/secret=
+# <uuid>). A bare UUID with NO secret-ish key in front is treated as an
+# identifier and left visible — that is the deliberate trade, and it is safe
+# ONLY because the secret_assignment/bearer_token context patterns cover the
+# cases where a UUID actually is a credential.
 _add('heroku_key',
      r'heroku[A-Za-z0-9_]*[\s:="\']+([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})')
 
 # ── Generic bearer/auth tokens ──
 _add('bearer_token',
      r'(?:bearer|authorization|token|auth)[\s:=]+["\']?([A-Za-z0-9._~+/=-]{32,})["\']?')
+
+# ── Generic secret-assignment catch-all ──
+# The vendor patterns above each need a recognisable prefix or a 32+ char body,
+# so a short/odd-shaped value after a secret keyword (api_key=abcd, secret=hunter2,
+# token=shortvalue, api_key=<uuid>) would otherwise reach the audit log in clear
+# text — the exact gap the old audit_log.py catch-all covered before it was
+# collapsed onto this module (review feedback). Match ANY non-empty value after a
+# secret-ish key so nothing short or unrecognised slips through. In an audit log,
+# over-redaction is the safe failure.
+_add('secret_assignment',
+     r'\b(?:api[_-]?key|apikey|secret|token|auth[_-]?token|access[_-]?key)'
+     r'\s*[=:]\s*["\']?([^\s"\',;}]+)')
 
 # ── Passwords ──
 _add('password_assignment',

--- a/tests/unit/test_consent_revoke_side_effects_parity.py
+++ b/tests/unit/test_consent_revoke_side_effects_parity.py
@@ -1,0 +1,73 @@
+"""Parallel-path fix #4 (revoke half): the JWT consent UI surface
+(``consent_api.revoke_consent``) flipped ``revoked_at`` on its own append-only
+row but — unlike the canonical ``ConsentService.revoke_consent`` — wrote NO
+immutable-audit entry and emitted NO ``consent.revoked`` event. A UI revoke thus
+left no compliance trail and never reached WAMP/SSE listeners or the user's other
+devices, drifting from the service path.
+
+The UI surface deliberately keeps its OWN row model (append-only: ``granted``
+stays True, ``revoked_at`` is the tombstone), which is NOT the service's
+``granted=False`` + agent_id-keyed model — so delegating the WRITE would corrupt
+the append-only audit trail. What must not drift are the observable SIDE EFFECTS:
+this pins that the UI revoke now routes its audit + broadcast through the SAME
+canonical helpers the service uses, while still NOT delegating the write.
+"""
+import re
+from pathlib import Path
+
+from integrations.social import consent_service as cs
+
+
+def _revoke_body() -> str:
+    src = (Path(cs.__file__).resolve().parent
+           / 'consent_api.py').read_text(encoding='utf-8')
+    m = re.search(r"def revoke_consent\(\):.*?(?=\n@|\ndef |\Z)", src, re.DOTALL)
+    assert m, "revoke_consent not found"
+    return m.group(0)
+
+
+def test_ui_revoke_routes_side_effects_through_canonical_helpers():
+    body = _revoke_body()
+    # fires the side effects through the service's PUBLIC entry point, NOT by
+    # reaching into its underscore-private _audit/_emit (that left parity
+    # "maintained by the caller remembering to do it" — review feedback).
+    assert 'ConsentService.announce_revocation(' in body, \
+        "UI revoke must call the public ConsentService.announce_revocation"
+    assert not re.search(r"import .*\b_audit\b", body) and \
+        not re.search(r"import .*\b_emit\b", body), \
+        "UI revoke must NOT import the private _audit/_emit symbols"
+
+
+def test_ui_revoke_keeps_its_append_only_row_model():
+    body = _revoke_body()
+    # still the tombstone write (unchanged behaviour)
+    assert 'revoked_at' in body, "UI revoke must still set revoked_at"
+    # must NOT adopt the service's granted=False model (would break append-only)
+    assert not re.search(r"\.granted\s*=\s*False", body), \
+        "UI revoke must not flip granted=False — that corrupts the append-only trail"
+    # must NOT delegate the WRITE to the service (row models are incompatible).
+    # Check for an actual CALL (open paren) so a comment that merely NAMES the
+    # service method for context does not trip this.
+    assert 'ConsentService.revoke_consent(' not in body, \
+        "UI revoke keeps its own row selection; only side effects are shared"
+
+
+def test_announce_revocation_is_public_and_best_effort():
+    """The public entry point fires the audit + broadcast and never raises into
+    the request path — so any caller (service or UI) gets identical, structural
+    parity without touching module privates."""
+    assert callable(getattr(cs.ConsentService, 'announce_revocation', None)), \
+        "announce_revocation must be a public ConsentService method"
+    # must not raise even with a degenerate/empty payload (event bus + audit are
+    # both best-effort under the hood)
+    cs.ConsentService.announce_revocation('', 'data_access', '*', None)
+
+
+def test_service_revoke_routes_side_effects_through_the_public_method():
+    """ConsentService.revoke_consent must fire the side effects via
+    announce_revocation, so the two writers share ONE emit path structurally."""
+    import re as _re
+    import inspect
+    src = inspect.getsource(cs.ConsentService.revoke_consent)
+    assert 'announce_revocation(' in src, \
+        "service revoke must go through announce_revocation, not inline _audit/_emit"

--- a/tests/unit/test_redactor_secret_assignment_gap.py
+++ b/tests/unit/test_redactor_secret_assignment_gap.py
@@ -1,0 +1,53 @@
+"""The canonical redactor must not let a secret-assignment slip through in clear.
+
+When audit_log's redaction was collapsed onto the one canonical
+``security.secret_redactor``, the delete of audit_log's own generic catch-all
+(``(password|...|api_key|apikey)\\s*[=:]\\s*\\S+``) left a hole: every vendor
+pattern in the canonical set needs a recognisable prefix or a 32+ char body, so a
+short or odd-shaped value after a secret keyword reached the audit log — the one
+artifact whose whole purpose is to be safe to keep and hand over. The
+``heroku_key`` narrowing (anchoring on a heroku context so identifier UUIDs stay
+visible) widened the same hole for ``api_key=<uuid>`` shapes.
+
+A ``secret_assignment`` catch-all closes both at their single home. This pins:
+  * secret-ish key = ANY value (short, uuid-shaped, unrecognised) is redacted;
+  * a bare identifier UUID with no secret key in front stays visible (the
+    "which node failed" diagnostic the heroku fix restored must survive).
+"""
+from security.secret_redactor import redact_secrets
+
+
+_UUID = '46329c87-cbb6-4ca1-bad5-816f6007b6a0'
+
+# Every one of these leaked through the canonical set before the fix.
+_MUST_REDACT = [
+    'api_key=abcd1234efgh',
+    'apikey: 9f8e7d6c',
+    'secret=hunter2',
+    'token=shortvalue',            # bearer_token needs 32+ chars; this is shorter
+    f'api_key={_UUID}',            # heroku narrowing let this through
+    f'secret: {_UUID}',
+    'access_key=xyz123',
+    'auth_token=q1w2e3',
+]
+
+# These must stay in clear text — they are diagnostics, not secrets.
+_MUST_STAY_VISIBLE = [
+    f'sync: FAILED TO SIGN batch for node_id={_UUID} — sending UNSIGNED 403',
+    f'hierarchy_sync: NO peer row resolves node_id={_UUID}',
+    f'request_id={_UUID} trace complete',
+]
+
+
+def test_secret_assignments_never_reach_the_log_in_clear():
+    for case in _MUST_REDACT:
+        out, _ = redact_secrets(case)
+        assert 'REDACTED' in out and 'hunter2' not in out and 'shortvalue' not in out, \
+            f'secret leaked through the canonical redactor: {case!r} -> {out!r}'
+
+
+def test_identifier_uuids_stay_visible():
+    for case in _MUST_STAY_VISIBLE:
+        out, _ = redact_secrets(case)
+        assert _UUID in out, \
+            f'identifier UUID was redacted — kills the diagnostic: {case!r} -> {out!r}'

--- a/tests/unit/test_trust_contract_canonical_payload.py
+++ b/tests/unit/test_trust_contract_canonical_payload.py
@@ -1,0 +1,89 @@
+"""The trust-contract signer/verifier must route through the ONE canonical
+Ed25519 serialization, byte-for-byte — never its own inline copy.
+
+`security/pre_trust_contract.py` carried a 6th inline copy of
+`json.dumps(..., sort_keys=True, separators=(',', ':'))` in `_contract_payload`.
+Every such copy is a network-wide-signature-break waiting to happen: the moment
+one signer's serialization drifts from a verifier's (a stray space, `sort_keys`
+flipped, a different separator), every trust contract that node signs fails
+verification on every peer with no obvious cause. This pins the collapse:
+
+  1. `_contract_payload` produces EXACTLY the bytes the canonical
+     `security.node_integrity.canonical_payload` produces for the signed field
+     set — so the serialization can only live in one place.
+  2. It returns bytes (the canonical UTF-8), and a real sign -> verify round trip
+     still holds — proving old signatures keep verifying (no flag day).
+  3. Tampering with any signed field is still rejected.
+"""
+import json
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey, Ed25519PublicKey,
+)
+
+from security.node_integrity import canonical_payload
+import security.pre_trust_contract as ptc
+
+
+_SIGNED_FIELDS = {
+    'node_id': 'node-1',
+    'public_key_hex': 'ab12cd',
+    'contract_fingerprint': 'cf-xyz',
+    'guardrail_hash': 'gh-123',
+    'origin_fingerprint': 'of-789',
+    'audit_compute_ratio': 0.8,
+    'signed_at': 1234567.5,
+}
+
+
+def _contract(**over):
+    fields = {**_SIGNED_FIELDS, **over}
+    return ptc.TrustContract(**fields)
+
+
+def test_payload_is_the_canonical_serialization_byte_for_byte():
+    """The single-source guarantee: identical bytes to canonical_payload, and
+    identical to the exact legacy json.dumps the inline copy used."""
+    c = _contract()
+    got = ptc._contract_payload(c)
+
+    # The helper keeps its long-standing str return type — callers (and the
+    # existing tests/unit/test_pre_trust_contract.py helper) .encode('utf-8')
+    # at the call site, so changing it to bytes would break every one of them.
+    assert isinstance(got, str), 'must keep the str return type callers rely on'
+
+    # equals the ONE canonical serializer over the same signed field-set
+    assert got.encode('utf-8') == canonical_payload(_SIGNED_FIELDS, exclude=())
+
+    # equals the legacy inline serialization it replaced (no flag-day break)
+    legacy = json.dumps(_SIGNED_FIELDS, sort_keys=True, separators=(',', ':'))
+    assert got == legacy
+
+
+def test_sign_then_verify_round_trips():
+    priv = Ed25519PrivateKey.generate()
+    pub_hex = priv.public_key().public_bytes_raw().hex()
+    c = _contract(public_key_hex=pub_hex)
+
+    c.signature_hex = priv.sign(ptc._contract_payload(c).encode('utf-8')).hex()
+
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(c.public_key_hex))
+    # raises on an invalid signature; no exception == verified
+    pub.verify(bytes.fromhex(c.signature_hex),
+               ptc._contract_payload(c).encode('utf-8'))
+
+
+def test_tampering_a_signed_field_breaks_the_signature():
+    priv = Ed25519PrivateKey.generate()
+    pub_hex = priv.public_key().public_bytes_raw().hex()
+    c = _contract(public_key_hex=pub_hex)
+    c.signature_hex = priv.sign(ptc._contract_payload(c).encode('utf-8')).hex()
+
+    c.node_id = 'evil-node'  # flip a signed field after signing
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(c.public_key_hex))
+    try:
+        pub.verify(bytes.fromhex(c.signature_hex),
+                   ptc._contract_payload(c).encode('utf-8'))
+        assert False, 'a tampered signed field must fail verification'
+    except Exception:
+        pass


### PR DESCRIPTION
Fixes from the `HARTOS_PARALLEL_PATH_AUDIT.md` audit — each collapses a duplicate/drifted code path or closes the security gap it caused. **11 commits, each with a unit test + a self-reviewed description.** Every serialization/security change is byte-/behaviour-preserving (proven in the tests).

Format below: **Problem → Fix**.

### Security
1. **shell-auth decorator drift** — the local-shell auth decorator was copied in 3 files and diverged; `shell_os_apis` trusted `0.0.0.0` (a bind-any sentinel) as "local", so an unauthenticated request reading `remote_addr=0.0.0.0` reached the os-shell routes. → **one canonical `shell_auth.py`; all surfaces alias it; `0.0.0.0` no longer trusted** (test: `0.0.0.0`→403).
2. **audit-log key leak** — `audit_log` had its own copy of the secret-redaction regexes and drifted from the canonical `secret_redactor` (missed `sk-proj-`, `sk-ant-`, non-`Sy` Google keys), so real API keys leaked into the audit log. → **delegate to the canonical `secret_redactor`** (added Groq too).
3. **unauthenticated power route** — `/api/shell/session/<action>` (shutdown/restart/firmware) had **no auth**, while its sibling did; any reachable caller could power off the box. → **gate it with the canonical `@_require_shell_auth`** (test: non-local→403).
4. **app-launch masked failures** — `/api/shell/launch` did a fire-and-forget `Popen(['gtk-launch'…])` that returned `{'status':'launched'}` even on failure, and was unauthenticated. → **delegate to the result-checked `get_app_bridge().launch_app` (real 500 on failure) + add auth**.
5. **Ed25519 signature-serialization drift** — the canonical-JSON payload used for signing/verifying was re-implemented inline in 4 security modules; any drift = signatures silently fail network-wide. → **one `node_integrity.canonical_payload`; routed `node_integrity`/`master_key`/`key_delegation`/`origin_attestation` through it, byte-identically** (test: byte-identical + sign→verify round-trip + a routed `verify_certificate_signature` still accepts a `canonical_payload`-signed cert).

### Compliance / correctness
6. **consent UI skipped the audit trail** — `consent_api.grant_consent` inserted the row inline, so UI-driven grants left no immutable-audit entry, no event, no `public_exposure` up-sync, and accepted arbitrary types. → **delegate to the canonical `ConsentService.grant_consent`**.
7. **`get_node_identity` name collision** — two different functions (crypto identity vs onboarding identity) shared the name and both returned a `tier` dict → importing the wrong module silently returned the wrong dict. → **rename the onboarding one to `get_onboarding_identity`** (4 callers updated; crypto one untouched).
8. **`verify_guardrail_integrity` name collision** — two functions, one name, **different return types** (`bool` vs `(bool,str)`) → `ok,msg = …` unpacking broke / `if …():` always truthy. → **rename the brand-check one to `verify_guardrail_brand_integrity`**.
9. **duplicate dispatch payloads** — `_dispatch_to_model` and `_dispatch_expert_langchain` built a char-identical inner-`/chat` payload inline; a field added to one would silently diverge the other. → **one `_build_dispatch_payload`, both call it**.
10. **LLM refusal-guard drift** — `CustomGPT` routed through `_pooled_post_with_refusal_check` (detect+retry a draft refusal) but `ChatQwen3VL` used raw `pooled_post`, so a refusal from that wrapper flowed straight to the user. → **route `ChatQwen3VL` through the same guard**.

### Data integrity
11. **corrupt-config-on-crash** — `create_recipe.py` wrote agent/recipe configs with a non-atomic `open('w')+json.dump`; a crash mid-write left a truncated config that `get_prompt_config_json` then KeyError-crashed on. → **route the config saves through the canonical `atomic_json_write` (tmp→fsync→os.replace)**.

---
Deferred (with reasons) — `#8 TaskStatus` (vendored `agent-ledger` package), `consent revoke` + `pre_trust_contract` (different builder/selection, need per-call review), and the broad `HEVOLVE_NODE_TIER`/`atomic_json` sweeps (mostly legitimate sites) — see the audit's remaining rows.
