### PR TITLE
fix(trust-contract): route signer/verifier through the ONE canonical Ed25519 serialization (parallel-path #6)

### DIFF
--- a/security/pre_trust_contract.py
+++ b/security/pre_trust_contract.py
@@ -132,8 +132,18 @@ class TrustContract:
     expelled: bool = False        # Whether node has been expelled
 
 
-def _contract_payload(contract: TrustContract) -> str:
-    """Canonical payload for signing/verification (excludes signature itself)."""
+def _contract_payload(contract: TrustContract) -> bytes:
+    """Canonical payload BYTES for signing/verification (excludes signature itself).
+
+    Routes through the ONE canonical serialization
+    (``security.node_integrity.canonical_payload``) instead of re-implementing
+    ``json.dumps(sort_keys=True, separators=(',', ':'))`` inline. This was the 6th
+    inline copy of that serialization in the codebase; any drift between a signer's
+    copy and a verifier's copy silently breaks every trust-contract signature
+    network-wide. The seven fields below ARE exactly the signed set, so nothing is
+    stripped at serialization time (``exclude=()``) — the field selection stays
+    local and explicit, only the byte-level serialization is delegated.
+    """
     payload = {
         'node_id': contract.node_id,
         'public_key_hex': contract.public_key_hex,
@@ -143,7 +153,8 @@ def _contract_payload(contract: TrustContract) -> str:
         'audit_compute_ratio': contract.audit_compute_ratio,
         'signed_at': contract.signed_at,
     }
-    return json.dumps(payload, sort_keys=True, separators=(',', ':'))
+    from security.node_integrity import canonical_payload
+    return canonical_payload(payload, exclude=())
 
 
 def sign_trust_contract(
@@ -192,9 +203,9 @@ def sign_trust_contract(
         signed_at=time.time(),
     )
 
-    # Sign the canonical payload
+    # Sign the canonical payload (already the canonical UTF-8 bytes)
     payload = _contract_payload(contract)
-    signature = priv_key.sign(payload.encode('utf-8'))
+    signature = priv_key.sign(payload)
     contract.signature_hex = signature.hex()
 
     logger.info(
@@ -259,7 +270,7 @@ def verify_trust_contract(contract: TrustContract) -> Tuple[bool, str]:
         pub_key = Ed25519PublicKey.from_public_bytes(pub_bytes)
         payload = _contract_payload(contract)
         sig_bytes = bytes.fromhex(contract.signature_hex)
-        pub_key.verify(sig_bytes, payload.encode('utf-8'))
+        pub_key.verify(sig_bytes, payload)
     except Exception as e:
         return False, f'Invalid contract signature: {e}'
 

--- a/tests/unit/test_trust_contract_canonical_payload.py
+++ b/tests/unit/test_trust_contract_canonical_payload.py
@@ -1,0 +1,85 @@
+"""The trust-contract signer/verifier must route through the ONE canonical
+Ed25519 serialization, byte-for-byte — never its own inline copy.
+
+`security/pre_trust_contract.py` carried a 6th inline copy of
+`json.dumps(..., sort_keys=True, separators=(',', ':'))` in `_contract_payload`.
+Every such copy is a network-wide-signature-break waiting to happen: the moment
+one signer's serialization drifts from a verifier's (a stray space, `sort_keys`
+flipped, a different separator), every trust contract that node signs fails
+verification on every peer with no obvious cause. This pins the collapse:
+
+  1. `_contract_payload` produces EXACTLY the bytes the canonical
+     `security.node_integrity.canonical_payload` produces for the signed field
+     set — so the serialization can only live in one place.
+  2. It returns bytes (the canonical UTF-8), and a real sign -> verify round trip
+     still holds — proving old signatures keep verifying (no flag day).
+  3. Tampering with any signed field is still rejected.
+"""
+import json
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey, Ed25519PublicKey,
+)
+
+from security.node_integrity import canonical_payload
+import security.pre_trust_contract as ptc
+
+
+_SIGNED_FIELDS = {
+    'node_id': 'node-1',
+    'public_key_hex': 'ab12cd',
+    'contract_fingerprint': 'cf-xyz',
+    'guardrail_hash': 'gh-123',
+    'origin_fingerprint': 'of-789',
+    'audit_compute_ratio': 0.8,
+    'signed_at': 1234567.5,
+}
+
+
+def _contract(**over):
+    fields = {**_SIGNED_FIELDS, **over}
+    return ptc.TrustContract(**fields)
+
+
+def test_payload_is_the_canonical_serialization_byte_for_byte():
+    """The single-source guarantee: identical bytes to canonical_payload, and
+    identical to the exact legacy json.dumps the inline copy used."""
+    c = _contract()
+    got = ptc._contract_payload(c)
+
+    assert isinstance(got, bytes), 'must be the canonical UTF-8 bytes, not a str'
+
+    # equals the ONE canonical serializer over the same signed field-set
+    assert got == canonical_payload(_SIGNED_FIELDS, exclude=())
+
+    # equals the legacy inline serialization it replaced (no flag-day break)
+    legacy = json.dumps(
+        _SIGNED_FIELDS, sort_keys=True, separators=(',', ':')).encode('utf-8')
+    assert got == legacy
+
+
+def test_sign_then_verify_round_trips():
+    priv = Ed25519PrivateKey.generate()
+    pub_hex = priv.public_key().public_bytes_raw().hex()
+    c = _contract(public_key_hex=pub_hex)
+
+    c.signature_hex = priv.sign(ptc._contract_payload(c)).hex()
+
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(c.public_key_hex))
+    # raises on an invalid signature; no exception == verified
+    pub.verify(bytes.fromhex(c.signature_hex), ptc._contract_payload(c))
+
+
+def test_tampering_a_signed_field_breaks_the_signature():
+    priv = Ed25519PrivateKey.generate()
+    pub_hex = priv.public_key().public_bytes_raw().hex()
+    c = _contract(public_key_hex=pub_hex)
+    c.signature_hex = priv.sign(ptc._contract_payload(c)).hex()
+
+    c.node_id = 'evil-node'  # flip a signed field after signing
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(c.public_key_hex))
+    try:
+        pub.verify(bytes.fromhex(c.signature_hex), ptc._contract_payload(c))
+        assert False, 'a tampered signed field must fail verification'
+    except Exception:
+        pass


### PR DESCRIPTION
Completes the last open file in **audit item #6** (Ed25519 sign/verify canonicalisation) from `HARTOS_PARALLEL_PATH_AUDIT.md`. The other five (`master_key`, `key_delegation`, `origin_attestation`, and `node_integrity` itself) already route through the canonical serializer via #113; this is the sixth.

### Problem
`security/pre_trust_contract.py:_contract_payload` carried its **own inline copy** of
```python
json.dumps(payload, sort_keys=True, separators=(',', ':'))
```
That is the 6th such copy in the codebase. Each copy is a latent **network-wide signature break**: the instant one node's signer serialization drifts from a peer's verifier (a stray space, `sort_keys` flipped, a different separator), every trust contract that node signs fails verification on every peer — with no obvious cause. This is exactly the sign/verify-asymmetry class the audit flagged.

### Fix
`_contract_payload` now delegates to `security.node_integrity.canonical_payload(payload, exclude=())`:
- The **seven fields are the signed set**, so the field selection stays local and explicit; only the byte-level serialization is centralised (`exclude=()` strips nothing).
- Verified **byte-identical** to the previous inline `json.dumps` — existing signatures keep verifying, **no flag day**.
- Returns `bytes` now; the two sign/verify sites drop their redundant `.encode('utf-8')`.

### Deliberately NOT touched
`native_hive_loader` (the other name under audit #6) verifies over a **content hash**, not a canonical-JSON payload — a different primitive that does not belong behind `canonical_payload`.

### Tests
`tests/unit/test_trust_contract_canonical_payload.py`:
1. `_contract_payload` is byte-for-byte equal to `canonical_payload` **and** to the exact legacy `json.dumps` it replaced (single-source + no flag-day).
2. A real sign → verify round trip holds.
3. Tampering any signed field is rejected.

All three pass locally.