### PR TITLE
fix(consent): UI revoke must leave an audit trail + broadcast, like the canonical service (parallel-path #4, revoke half)

### DIFF
--- a/integrations/social/consent_api.py
+++ b/integrations/social/consent_api.py
@@ -213,6 +213,29 @@ def revoke_consent():
     row.revoked_at = now
     g.db.flush()
 
+    # Parallel-path parity (audit #4): this UI surface keeps its OWN append-only
+    # row model on purpose — granted stays True and revoked_at is the tombstone
+    # (see the module docstring), which is deliberately NOT the same as
+    # ConsentService.revoke_consent's granted=False + agent_id-keyed row model,
+    # so we do not delegate the write (that would corrupt the append-only audit
+    # trail). But the observable SIDE EFFECTS must not drift between the two
+    # writers: route the immutable-audit entry and the consent.revoked broadcast
+    # through the SAME canonical helpers the service uses. Previously a UI revoke
+    # left no audit entry and never reached WAMP/SSE listeners or the user's
+    # other devices — a compliance + propagation gap. Both helpers are
+    # best-effort (never raise), so this cannot fail the revoke.
+    _agent_id = getattr(row, 'agent_id', None)
+    from .consent_service import _audit as _consent_audit, _emit as _consent_emit
+    _consent_audit('consent', actor_id=uid,
+                   action=f'consent.revoked:{consent_type}',
+                   detail={'scope': scope, 'agent_id': _agent_id})
+    _consent_emit('consent.revoked', {
+        'user_id': uid,
+        'consent_type': consent_type,
+        'scope': scope,
+        'agent_id': _agent_id,
+    })
+
     logger.info(
         'consent.revoke user=%s type=%s scope=%s id=%s',
         uid, consent_type, scope, row.id,

--- a/tests/unit/test_consent_revoke_side_effects_parity.py
+++ b/tests/unit/test_consent_revoke_side_effects_parity.py
@@ -1,0 +1,62 @@
+"""Parallel-path fix #4 (revoke half): the JWT consent UI surface
+(``consent_api.revoke_consent``) flipped ``revoked_at`` on its own append-only
+row but — unlike the canonical ``ConsentService.revoke_consent`` — wrote NO
+immutable-audit entry and emitted NO ``consent.revoked`` event. A UI revoke thus
+left no compliance trail and never reached WAMP/SSE listeners or the user's other
+devices, drifting from the service path.
+
+The UI surface deliberately keeps its OWN row model (append-only: ``granted``
+stays True, ``revoked_at`` is the tombstone), which is NOT the service's
+``granted=False`` + agent_id-keyed model — so delegating the WRITE would corrupt
+the append-only audit trail. What must not drift are the observable SIDE EFFECTS:
+this pins that the UI revoke now routes its audit + broadcast through the SAME
+canonical helpers the service uses, while still NOT delegating the write.
+"""
+import re
+from pathlib import Path
+
+from integrations.social import consent_service as cs
+
+
+def _revoke_body() -> str:
+    src = (Path(cs.__file__).resolve().parent
+           / 'consent_api.py').read_text(encoding='utf-8')
+    m = re.search(r"def revoke_consent\(\):.*?(?=\n@|\ndef |\Z)", src, re.DOTALL)
+    assert m, "revoke_consent not found"
+    return m.group(0)
+
+
+def test_ui_revoke_routes_side_effects_through_canonical_helpers():
+    body = _revoke_body()
+    # imports the canonical audit + emit helpers from the service module
+    assert re.search(r"from \.consent_service import .*\b_audit\b", body), \
+        "UI revoke must use the canonical _audit helper"
+    assert re.search(r"from \.consent_service import .*\b_emit\b", body), \
+        "UI revoke must use the canonical _emit helper"
+    # and actually fires the revoked audit + broadcast
+    assert 'consent.revoked' in body, \
+        "UI revoke must emit consent.revoked like the service path"
+
+
+def test_ui_revoke_keeps_its_append_only_row_model():
+    body = _revoke_body()
+    # still the tombstone write (unchanged behaviour)
+    assert 'revoked_at' in body, "UI revoke must still set revoked_at"
+    # must NOT adopt the service's granted=False model (would break append-only)
+    assert not re.search(r"\.granted\s*=\s*False", body), \
+        "UI revoke must not flip granted=False — that corrupts the append-only trail"
+    # must NOT delegate the WRITE to the service (row models are incompatible).
+    # Check for an actual CALL (open paren) so a comment that merely NAMES the
+    # service method for context does not trip this.
+    assert 'ConsentService.revoke_consent(' not in body, \
+        "UI revoke keeps its own row selection; only side effects are shared"
+
+
+def test_emit_helper_is_best_effort_so_it_cannot_fail_the_revoke():
+    """The added calls must never raise into the request path."""
+    # emit swallows a broken event bus AND a broken notification path
+    cs._emit('consent.revoked', {'user_id': '', 'consent_type': 'data_access',
+                                 'scope': '*', 'agent_id': None})
+    # _audit likewise degrades to the in-memory fallback and never raises
+    cs._audit('consent', actor_id='u1', action='consent.revoked:data_access',
+              detail={'scope': '*', 'agent_id': None})


### PR DESCRIPTION
Completes **audit item #4** — the *revoke* half. #113 fixed the grant half (UI grant now delegates to `ConsentService.grant_consent`); this closes the matching gap on revoke.

### Problem
`consent_api.revoke_consent` (the JWT consent UI surface) flips `revoked_at` on its own row but — unlike the canonical `ConsentService.revoke_consent` — writes **no immutable-audit entry** and emits **no `consent.revoked` event**. So a UI-driven revoke:
- leaves **no compliance trail** of the revocation, and
- never reaches WAMP/SSE listeners or the user's **other devices**.

Same drift class #113 fixed for grant, on the revoke path.

### Why this isn't a straight delegate (and why that matters for safety)
Grant could delegate the whole WRITE to the service because the row models matched. **Revoke cannot:**
| | UI surface (`consent_api`) | Service (`ConsentService`) |
|--|--|--|
| tombstone | append-only: `granted` stays True, `revoked_at` set | `granted=False` + `revoked_at` |
| row select | most-recent active, `granted_at desc` | `agent_id`-keyed, `first()` |

Delegating the write would **corrupt the UI surface's append-only audit trail** (its module docstring is emphatic that `granted_at`/the grant event is immutable history). So this shares only the **side effects**: the UI revoke now routes its audit entry + `consent.revoked` broadcast through the **same canonical `_audit`/`_emit` helpers** the service uses, while keeping its own row model untouched.

Both helpers are **best-effort (never raise)**, so the added calls cannot fail the revoke — **zero behavioural regression** to the tombstone write itself.

### Tests
`tests/unit/test_consent_revoke_side_effects_parity.py`:
1. UI revoke routes side effects through the canonical `_audit`/`_emit` and emits `consent.revoked`.
2. It **keeps** its append-only model — still sets `revoked_at`, never flips `granted=False`, never delegates the write.
3. `_emit`/`_audit` are best-effort (degrade silently), so they can't break the request.

All pass (source-inspection + best-effort behavioural checks); `py_compile` clean.