### PR TITLE
fix(wamp): make the node relay bridge fully work on Windows — connect + receive

### DIFF
--- a/core/platform/events.py
+++ b/core/platform/events.py
@@ -361,6 +361,7 @@ class EventBus:
         """
         try:
             from autobahn.asyncio.component import Component
+            from autobahn.wamp.types import SubscribeOptions
         except ImportError:
             logger.warning("autobahn not installed — WAMP bridge unavailable")
             return False
@@ -381,7 +382,7 @@ class EventBus:
             wamp_wildcard = f'{WAMP_TOPIC_PREFIX}.'
             try:
                 await session.subscribe(bus._on_wamp_event, wamp_wildcard,
-                                        options={'match': 'prefix'})
+                                        options=SubscribeOptions(match='prefix', details_arg='details'))
                 logger.info("EventBus subscribed to WAMP prefix: %s", wamp_wildcard)
             except Exception as e:
                 logger.warning("WAMP wildcard subscribe failed: %s", e)

--- a/hart_intelligence_entry.py
+++ b/hart_intelligence_entry.py
@@ -1,5 +1,15 @@
 # Fix Windows encoding for non-ASCII characters (Telugu, emojis, etc.)
 import sys
+# Windows: use the SelectorEventLoop policy process-wide.  autobahn's asyncio
+# WAMP transport breaks on the default Windows ProactorEventLoop — the
+# EventBus WAMP bridge (core/platform/events.py connect_wamp) opens the TCP
+# socket to the relay but the session never joins (on_join never fires), so
+# the internet relay stays dark on Windows while a macOS/Linux peer connects
+# fine.  autobahn resolves its loop through the global policy, so this must be
+# set before any loop is created; hypercorn serves cleanly on a selector loop.
+if sys.platform == 'win32':
+    import asyncio as _asyncio_boot
+    _asyncio_boot.set_event_loop_policy(_asyncio_boot.WindowsSelectorEventLoopPolicy())
 from core.subprocess_safe import no_window_kwargs
 import io
 if sys.platform == 'win32' and 'pytest' not in sys.modules:


### PR DESCRIPTION
Two tightly-related fixes so a HART OS node actually participates in the WAMP/Crossbar relay hive on Windows — it now both **connects** and **receives**, not just publishes.

### 1. Bridge connects on Windows — `hart_intelligence_entry.py`
On Windows the default `ProactorEventLoop` breaks autobahn's WebSocket transport, so `on_join` never fired and the EventBus WAMP bridge never came up. Set `WindowsSelectorEventLoopPolicy` at process boot (autobahn resolves the loop via the global policy).

### 2. Bridge stops silently dropping every inbound event — `core/platform/events.py`
`EventBus.connect_wamp()` subscribed to the WAMP wildcard prefix **without requesting event details**, so autobahn never injected the `details` object into `_on_wamp_event()`. The handler resolves the concrete topic via `details.topic` and bails (`if not wamp_topic: return`) when it's missing — which was **always** — so every inbound relay event was dropped before local dispatch.

Net effect before the fix: the node published its own telemetry fine but never received or re-dispatched any remote hive event (peer telemetry, `federation.aggregated`, `hive.benchmark.completed`, `agent.action.*`) — it spoke on the relay but never listened.

Fix: `options=SubscribeOptions(match='prefix', details_arg='details')` so autobahn injects the `EventDetails` as the `details` kwarg the handler already expects.

### Verification
- Windows node's WAMP bridge now joins `realm1` on `ws://azurekong.hertzai.com:8088/ws` and stays connected.
- Round-trip proven on the live relay both directions (independent subscriber + router-acked publishes).
- Receive fix verified against a node-shaped handler: `details.topic` now resolves and the event is dispatched instead of dropped (VERDICT PASS).

Scope: only the two files above; no unrelated changes.