### PR TITLE
test(eventbus): pin WAMP prefix subscribe to details_arg='details'

### DIFF
--- a/tests/unit/test_eventbus_wamp_tts.py
+++ b/tests/unit/test_eventbus_wamp_tts.py
@@ -162,6 +162,56 @@ class TestEventBusWAMPBridge(unittest.TestCase):
             bus._wamp_loop.close()
             bus._wamp_loop = None
 
+    def test_connect_wamp_subscribes_with_details_arg(self):
+        """Regression: the WAMP prefix subscription MUST pass
+        details_arg='details'.
+
+        Without it autobahn never injects the EventDetails, so
+        _on_wamp_event's ``details`` is always None and every inbound
+        event hits ``if not wamp_topic: return`` — silently dropping all
+        remote hive events.  This pins the subscribe options so that
+        details=None silent-drop class cannot quietly reappear.
+        """
+        from core.platform.events import EventBus
+        from autobahn.wamp.types import SubscribeOptions
+        from unittest.mock import AsyncMock
+        import asyncio
+
+        bus = EventBus()
+        captured = {}
+        fake_component = MagicMock()
+        # Capture the handler registered via @component.on_join
+        fake_component.on_join.side_effect = (
+            lambda fn: captured.setdefault('on_join', fn) or fn
+        )
+        fake_component.on_leave.side_effect = lambda fn: fn
+
+        # Component(...) -> fake_component; don't start the background thread.
+        with patch('autobahn.asyncio.component.Component',
+                   return_value=fake_component), \
+                patch('threading.Thread'):
+            bus.connect_wamp('ws://fake:8088/ws', 'realm1')
+
+        self.assertIn('on_join', captured,
+                      "connect_wamp must register an on_join handler")
+
+        # Drive on_join with a mock session and inspect the subscribe call —
+        # this is the exact call the receive path depends on.
+        session = MagicMock()
+        session.subscribe = AsyncMock()
+        asyncio.run(captured['on_join'](session, MagicMock()))
+
+        session.subscribe.assert_awaited_once()
+        opts = session.subscribe.call_args.kwargs.get('options')
+        self.assertIsInstance(
+            opts, SubscribeOptions,
+            "subscribe must be called with a SubscribeOptions instance")
+        self.assertEqual(
+            opts.details_arg, 'details',
+            "prefix subscription must request details_arg='details', else "
+            "autobahn drops every inbound event (details=None)")
+        self.assertEqual(opts.match, 'prefix')
+
 
 # ═══════════════════════════════════════════════════════════════
 # emit_event() module helper


### PR DESCRIPTION
Follow-up to the #118 review — the receive-path fix had no regression guard, and the "details=None → silent drop" class reintroduces easily.

## What this adds
One unit test in `tests/unit/test_eventbus_wamp_tts.py` that pins `EventBus.connect_wamp()`'s subscription options. It captures the `on_join` handler registered via `@component.on_join` (with `Component` and the background thread mocked), drives it with a mock session, and asserts:

- `session.subscribe(...)` is called with a `SubscribeOptions` instance
- `options.details_arg == 'details'`
- `options.match == 'prefix'`

If the option is dropped or the plain-dict form (`{'match': 'prefix'}`) returns, autobahn never injects `EventDetails`, `_on_wamp_event`'s `details` is `None`, and every inbound event hits `if not wamp_topic: return` — the test fails.

## Verification
- New test: PASS
- Full file: `35 passed` (no regression)

## From the #118 review, not included here (with reasons)
- **`pytest not in sys.modules` guard on the SelectorEventLoop policy block** — the review flagged it as minor/harmless; adding it would skip setting the selector policy under pytest, which is a behavioral change with no upside for this test, so I left it out to keep the diff test-only.
- **`hevolveai` `HiveMind.connect_wamp` sibling fix** — that module is closed-source and loaded at runtime; its source isn't in this repo, so it can't be fixed here. Worth a separate task at that process's entry.

Scope: one test file, additive only.